### PR TITLE
Update GJets k-factor,  Negative Weight Signs, and ZJetsToNuNu Samples

### DIFF
--- a/sampleCollections.cfg
+++ b/sampleCollections.cfg
@@ -16,7 +16,9 @@ TTbarExt, TTbarInc, TTbarSingleLepT, TTbarSingleLepTbar, TTbarDiLep, TTbar_HT-60
 WJetsToLNuInc, WJetsToLNu_Inc
 WJetsToLNu, WJetsToLNu_HT_2500toInf, WJetsToLNu_HT_1200to2500, WJetsToLNu_HT_800to1200, WJetsToLNu_HT_600to800, WJetsToLNu_HT_400to600, WJetsToLNu_HT_200to400, WJetsToLNu_HT_100to200, WJetsToLNu_HT_70to100
 
-ZJetsToNuNu, ZJetsToNuNu_HT_2500toInf, ZJetsToNuNu_HT_1200to2500, ZJetsToNuNu_HT_800to1200, ZJetsToNuNu_HT_600to800, ZJetsToNuNu_HT_400to600, ZJetsToNuNu_HT_200to400, ZJetsToNuNu_HT_100to200
+# The sample GJets_HT-100To200 is not available, and we remove ZJetsToNuNu_HT_100to200 for comparing ZJetsToNuNu to GJets. 
+#ZJetsToNuNu, ZJetsToNuNu_HT_2500toInf, ZJetsToNuNu_HT_1200to2500, ZJetsToNuNu_HT_800to1200, ZJetsToNuNu_HT_600to800, ZJetsToNuNu_HT_400to600, ZJetsToNuNu_HT_200to400, ZJetsToNuNu_HT_100to200
+ZJetsToNuNu, ZJetsToNuNu_HT_2500toInf, ZJetsToNuNu_HT_1200to2500, ZJetsToNuNu_HT_800to1200, ZJetsToNuNu_HT_600to800, ZJetsToNuNu_HT_400to600, ZJetsToNuNu_HT_200to400
 
 DYJetsToLL, DYJetsToLL_HT_2500toInf, DYJetsToLL_HT_1200to2500, DYJetsToLL_HT_800to1200, DYJetsToLL_HT_600to800, DYJetsToLL_HT_400to600, DYJetsToLL_HT_200to400, DYJetsToLL_HT_100to200, DYJetsToLL_HT_70to100
 

--- a/sampleSets.cfg
+++ b/sampleSets.cfg
@@ -86,7 +86,7 @@ tW_antitop_incl, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016
 tW_top_NoHad, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ST_tW_top_5f_NoFullyHadronicDecays_13TeV-powheg_TuneCUETP8M1.txt, stopTreeMaker/AUX, 19.42, 3916168, 0, 1.0
 tW_antitop_NoHad, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ST_tW_antitop_5f_NoFullyHadronicDecays_13TeV-powheg_TuneCUETP8M1.txt, stopTreeMaker/AUX, 19.42, 9578968, 0, 1.0
 
-ST_s, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ST_s-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1.txt, stopTreeMaker/AUX, 10.32, 3474246, -806517, 1.0
+ST_s, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ST_s-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1.txt, stopTreeMaker/AUX, 10.32, 3474246, 806517, 1.0
 ST_t_top, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ST_t-channel_top_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1.txt, stopTreeMaker/AUX, 136.02, 42139304, 0, 1.0
 ST_t_antitop, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ST_t-channel_antitop_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1.txt, stopTreeMaker/AUX, 80.95, 13895639, 0, 1.0
 
@@ -97,21 +97,21 @@ ST_tWnunu, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ST_
 
 # NLO --> negative weights!
 # (sign of gen weight) * (lumi*xsec)/(effective number of events): effective number of events = N(evt) with positive weight - N(evt) with negative weight
-TTZToLLNuNu, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, stopTreeMaker/AUX, 0.2529, 2522357, -917841, 1.0
-TTZToQQ, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, TTZToQQ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, stopTreeMaker/AUX, 0.5297, 514433, -186635, 1.0
+TTZToLLNuNu, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, stopTreeMaker/AUX, 0.2529, 2522357, 917841, 1.0
+TTZToQQ, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, TTZToQQ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, stopTreeMaker/AUX, 0.5297, 514433, 186635, 1.0
 
 # NLO --> negative weights!
-TTWJetsToLNu, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8.txt, stopTreeMaker/AUX, 0.2043, 539665, -172812, 1.0
-TTWJetsToQQ, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, TTWJetsToQQ_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8.txt, stopTreeMaker/AUX, 0.4062, 720756, -229750, 1.0
+TTWJetsToLNu, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8.txt, stopTreeMaker/AUX, 0.2043, 539665, 172812, 1.0
+TTWJetsToQQ, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, TTWJetsToQQ_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8.txt, stopTreeMaker/AUX, 0.4062, 720756, 229750, 1.0
 
-TTTT, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, TTTT_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, stopTreeMaker/AUX, 0.009103, 3870, -1586, 1.0
+TTTT, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, TTTT_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, stopTreeMaker/AUX, 0.009103, 3870, 1586, 1.0
 
 # NLO --> negative weights!  
-TTGJets, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, TTGJets_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8.txt, stopTreeMaker/AUX, 3.697, 61138588, -31229226, 1.0
+TTGJets, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, TTGJets_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8.txt, stopTreeMaker/AUX, 3.697, 61138588, 31229226, 1.0
 
 # ttH 
-ttHTobb, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ttHTobb_M125_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8.txt, stopTreeMaker/AUX, 0.2934, 2080846, -20038, 1.0
-ttHToNonbb, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ttHToNonbb_M125_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8.txt, stopTreeMaker/AUX, 0.2151, 2228755, -21323, 1.0
+ttHTobb, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ttHTobb_M125_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8.txt, stopTreeMaker/AUX, 0.2934, 2080846, 20038, 1.0
+ttHToNonbb, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ttHToNonbb_M125_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8.txt, stopTreeMaker/AUX, 0.2151, 2228755, 21323, 1.0
 GluGluHToZZTo4L, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, GluGluHToZZTo4L_M125_13TeV_powheg2_JHUgenV6_pythia8.txt, stopTreeMaker/AUX, 0.01212, 931650, 0, 1.0
 # VH --> negative weights!
 VHToNonbb, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, VHToNonbb_M125_13TeV_amcatnloFXFX_madspin_pythia8.txt, stopTreeMaker/AUX, 2.171, 0, 0, 1.0
@@ -124,23 +124,23 @@ WWToLNuQQ, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, WWT
 
 # Ref. https://twiki.cern.ch/twiki/bin/viewauth/CMS/SummaryTable1G25ns (NLO from MCFM)
 WZ, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, WZ_TuneCUETP8M1_13TeV-pythia8.txt, stopTreeMaker/AUX, 47.13, 3794243, 0, 1.0
-WZTo1L1Nu2Q, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, WZTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8.txt, stopTreeMaker/AUX, 10.71, 491380343, -130435224, 1.0
-WZTo1L3Nu, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, WZTo1L3Nu_13TeV_amcatnloFXFX_madspin_pythia8.txt, stopTreeMaker/AUX, 3.033, 5813263, -1677068, 1.0
-WZTo3LNu, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, WZTo3LNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8.txt, stopTreeMaker/AUX, 4.712, 111291460, -26181003, 1.0
+WZTo1L1Nu2Q, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, WZTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8.txt, stopTreeMaker/AUX, 10.71, 491380343, 130435224, 1.0
+WZTo1L3Nu, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, WZTo1L3Nu_13TeV_amcatnloFXFX_madspin_pythia8.txt, stopTreeMaker/AUX, 3.033, 5813263, 1677068, 1.0
+WZTo3LNu, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, WZTo3LNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8.txt, stopTreeMaker/AUX, 4.712, 111291460, 26181003, 1.0
 
-ZZTo2Q2Nu, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ZZTo2Q2Nu_13TeV_amcatnloFXFX_madspin_pythia8.txt, stopTreeMaker/AUX, 4.04, 199660934, -47726157, 1.0
+ZZTo2Q2Nu, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ZZTo2Q2Nu_13TeV_amcatnloFXFX_madspin_pythia8.txt, stopTreeMaker/AUX, 4.04, 199660934, 47726157, 1.0
 ZZTo2L2Nu, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ZZTo2L2Nu_13TeV_powheg_pythia8.txt, stopTreeMaker/AUX, 0.564, 8517400, 0, 1.0
-ZZTo2L2Q, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8.txt, stopTreeMaker/AUX, 3.22, 89338161, -20187737, 1.0
-ZZTo4Q, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ZZTo4Q_13TeV_amcatnloFXFX_madspin_pythia8.txt, stopTreeMaker/AUX, 6.842, 378439018, -89154607, 1.0
+ZZTo2L2Q, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8.txt, stopTreeMaker/AUX, 3.22, 89338161, 20187737, 1.0
+ZZTo4Q, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ZZTo4Q_13TeV_amcatnloFXFX_madspin_pythia8.txt, stopTreeMaker/AUX, 6.842, 378439018, 89154607, 1.0
 ZZTo4L, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ZZTo4L_13TeV_powheg_pythia8.txt, stopTreeMaker/AUX, 1.256, 3923114, 0, 1.0
 
 # Tri-boson: negative weights!
-WWW, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, WWW_4F_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, stopTreeMaker/AUX, 0.2086, 53512, -3499, 1.0
-WWZ, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, WWZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, stopTreeMaker/AUX, 0.1651, 43823, -2652, 1.0
-WZZ, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, WZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, stopTreeMaker/AUX, 0.05565, 14702, -966, 1.0
-ZZZ, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ZZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, stopTreeMaker/AUX, 0.01398, 3795, -295, 1.0
-WZG, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, WZG_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, stopTreeMaker/AUX, 0.04123, 41055, -3412, 1.0
-WWG, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, WWG_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, stopTreeMaker/AUX, 0.2147, 211869, -19918, 1.0
+WWW, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, WWW_4F_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, stopTreeMaker/AUX, 0.2086, 53512, 3499, 1.0
+WWZ, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, WWZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, stopTreeMaker/AUX, 0.1651, 43823, 2652, 1.0
+WZZ, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, WZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, stopTreeMaker/AUX, 0.05565, 14702, 966, 1.0
+ZZZ, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ZZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, stopTreeMaker/AUX, 0.01398, 3795, 295, 1.0
+WZG, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, WZG_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, stopTreeMaker/AUX, 0.04123, 41055, 3412, 1.0
+WWG, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, WWG_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, stopTreeMaker/AUX, 0.2147, 211869, 19918, 1.0
 
 # --------
 # - data -

--- a/sampleSets.cfg
+++ b/sampleSets.cfg
@@ -29,7 +29,8 @@ WJetsToLNu_HT_2500toInf, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8
 
 #Z -> nunu
 # From https://twiki.cern.ch/twiki/bin/viewauth/CMS/SummaryTable1G25ns#DY_Z, kz = 1.23
-ZJetsToNuNu_HT_100to200, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ZJetsToNuNu_HT-100To200_13TeV-madgraph.txt, stopTreeMaker/AUX, 280.35, 18496100, 0, 1.23
+# The sample GJets_HT-100To200 is not available, and we remove ZJetsToNuNu_HT_100to200 for comparing ZJetsToNuNu to GJets. 
+#ZJetsToNuNu_HT_100to200, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ZJetsToNuNu_HT-100To200_13TeV-madgraph.txt, stopTreeMaker/AUX, 280.35, 18496100, 0, 1.23
 ZJetsToNuNu_HT_200to400, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ZJetsToNuNu_HT-200To400_13TeV-madgraph.txt, stopTreeMaker/AUX, 77.67, 20632820, 0, 1.23
 ZJetsToNuNu_HT_400to600, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ZJetsToNuNu_HT-400To600_13TeV-madgraph.txt, stopTreeMaker/AUX, 10.73, 7761484, 0, 1.23
 ZJetsToNuNu_HT_600to800, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, ZJetsToNuNu_HT-600To800_13TeV-madgraph.txt, stopTreeMaker/AUX, 2.559, 5485367, 0, 1.23
@@ -51,8 +52,8 @@ DYJetsToLL_HT_2500toInf, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8
 # NNLO
 DYJetsToLL_Inc, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt, stopTreeMaker/AUX, 6025.2, 42092385, 0, 1.0
 
-#gamma + jets samples
-# The sample GJets_HT-100To200 is not ready yet.
+#gamma + jets samples, k = 1.26
+# The sample GJets_HT-100To200 is not available.
 #GJets_HT-100To200, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, GJets_DR-0p4_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt, stopTreeMaker/AUX, 5391, 0, 0, 1.26
 GJets_HT-200To400, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, GJets_DR-0p4_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt, stopTreeMaker/AUX, 1168, 42580140, 0, 1.26
 GJets_HT-400To600, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, GJets_DR-0p4_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt, stopTreeMaker/AUX, 132.5, 9007832, 0, 1.26

--- a/sampleSets.cfg
+++ b/sampleSets.cfg
@@ -53,10 +53,10 @@ DYJetsToLL_Inc, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/
 
 #gamma + jets samples
 # The sample GJets_HT-100To200 is not ready yet.
-#GJets_HT-100To200, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, GJets_DR-0p4_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt, stopTreeMaker/AUX, 5391, 0, 0, 1.0
-GJets_HT-200To400, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, GJets_DR-0p4_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt, stopTreeMaker/AUX, 1168, 42580140, 0, 1.0
-GJets_HT-400To600, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, GJets_DR-0p4_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt, stopTreeMaker/AUX, 132.5, 9007832, 0, 1.0
-GJets_HT-600ToInf, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, GJets_DR-0p4_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt, stopTreeMaker/AUX, 44.05, 10186996, 0, 1.0
+#GJets_HT-100To200, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, GJets_DR-0p4_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt, stopTreeMaker/AUX, 5391, 0, 0, 1.26
+GJets_HT-200To400, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, GJets_DR-0p4_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt, stopTreeMaker/AUX, 1168, 42580140, 0, 1.26
+GJets_HT-400To600, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, GJets_DR-0p4_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt, stopTreeMaker/AUX, 132.5, 9007832, 0, 1.26
+GJets_HT-600ToInf, /eos/uscms/store/user/lpcsusyhad/Stop_production/CMSSW8028_2016/, GJets_DR-0p4_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt, stopTreeMaker/AUX, 44.05, 10186996, 0, 1.26
 
 #QCD
 # Ref. https://twiki.cern.ch/twiki/bin/viewauth/CMS/SummaryTable1G25ns#QCD. But numbers are from McM.


### PR DESCRIPTION
- Change k-factor for GJets from 1.0 to 1.26
- Remove minus signs from negative weights
- Remove ZJetsToNuNu_HT_100to200 to compare ZJetsToNuNu to GJets (as GJets_HT-100To200 is not available)