### PR TITLE
Calculate Number of Events

### DIFF
--- a/sampleSets_PreProcessed_2016.cfg
+++ b/sampleSets_PreProcessed_2016.cfg
@@ -68,8 +68,8 @@ GJets_HT_600ToInf_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer1
 QCD_HT_100to200_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_22Feb2019, QCD_HT100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt, Events, 27990000, 82293477, 0, 1.0
 QCD_HT_200to300_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_11Apr2019, QCD_HT200to300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt, Events, 1712000, 57580393, 0, 1.0
 QCD_HT_300to500_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_22Feb2019, QCD_HT300to500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt, Events, 347700, 54552852, 0, 1.0
-QCD_HT_500to700_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_11Apr2019, QCD_HT500to700_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt, Events, 32100, 41193225, 0, 1.0 
-QCD_HT_700to1000_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_11Apr2019, QCD_HT700to1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt, Events, 6831, 36941498, 0, 1.0 
+QCD_HT_500to700_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_11Apr2019, QCD_HT500to700_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt, Events, 32100, 96208609, 0, 1.0
+QCD_HT_700to1000_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_11Apr2019, QCD_HT700to1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt, Events, 6831, 37102917, 0, 1.0
 QCD_HT_1000to1500_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_11Apr2019, QCD_HT1000to1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt, Events, 1207, 15210939, 0, 1.0
 QCD_HT_1500to2000_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_22Feb2019, QCD_HT1500to2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt, Events, 119.9, 12021227, 0, 1.0
 QCD_HT_2000toInf_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_22Feb2019, QCD_HT2000toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt, Events, 25.24, 6080644, 0, 1.0
@@ -107,7 +107,7 @@ TTWJetsToQQ_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_
 TTTT_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_22Feb2019, TTTT_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, Events, 0.009103, 177320, 72680, 1.0
 
 # NLO --> negative weights!  
-TTGJets_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_11Apr2019, TTGJets_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8.txt, Events, 3.697, 7695417, 3930555, 1.0
+TTGJets_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_11Apr2019, TTGJets_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8.txt, Events, 3.697, 5483163, 2803717, 1.0
 
 # ttH 
 ## From ttHToNonbb, invert by H->bb branch ratio 0.584: 0.215/0.584*(1-0.584): TODO: Not so sure as it diagreed with 050 value
@@ -141,9 +141,9 @@ ZZTo4Q_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/Pr
 #ZZTo4L_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_22Feb2019, ZZTo4L_13TeV_powheg_pythia8.txt, Events, 1.212, 0, 0, 1.0
 
 # Tri-boson: negative weights!
-WWW_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_22Mar2019, WWW_4F_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, Events, 0.2086, 0, 0, 1.0
+WWW_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_22Mar2019, WWW_4F_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, Events, 0.2086, 225269, 14731, 1.0
 WWZ_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_22Feb2019, WWZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, Events, 0.1651, 235734, 14266, 1.0
-WZZ_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_22Mar2019, WZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, Events, 0.05565, 0, 0, 1.0
+WZZ_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_22Mar2019, WZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, Events, 0.05565, 231583, 15217, 1.0
 ZZZ_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_22Mar2019, ZZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, Events, 0.01398, 231217, 18020, 1.0
 WZG_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_22Feb2019, WZG_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, Events, 0.04123, 921527, 76673, 1.0
 WWG_2016, /eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_22Feb2019, WWG_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt, Events, 0.2147, 913515, 85885, 1.0

--- a/sampleSets_PreProcessed_2017.cfg
+++ b/sampleSets_PreProcessed_2017.cfg
@@ -49,10 +49,10 @@ DYJetsToLL_HT_400to600_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fa
 DYJetsToLL_HT_600to800_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_15Jan2019, DYJetsToLL_M-50_HT-600to800_TuneCP5_13TeV-madgraphMLM-pythia8.txt, Events, 1.367, 6674273, 19900, 1.23
 DYJetsToLL_HT_800to1200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_15Jan2019, DYJetsToLL_M-50_HT-800to1200_TuneCP5_13TeV-madgraphMLM-pythia8.txt, Events, 0.6304, 3102346, 12634, 1.23
 DYJetsToLL_HT_1200to2500_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_15Jan2019, DYJetsToLL_M-50_HT-1200to2500_TuneCP5_13TeV-madgraphMLM-pythia8.txt, Events, 0.1514, 95634, 676, 1.23
-DYJetsToLL_HT_2500toInf_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_15Jan2019, DYJetsToLL_M-50_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8.txt, Events, 0.003565 410321, 8987, 1.23
+DYJetsToLL_HT_2500toInf_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_15Jan2019, DYJetsToLL_M-50_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8.txt, Events, 0.003565, 410321, 8987, 1.23
 
 # NNLO
-DYJetsToLL_Inc_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_15Jan2019/, DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8.txt, Events, 6225.42, 49429380, 0, 1.0
+DYJetsToLL_Inc_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_15Jan2019/, DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8.txt, Events, 6225.42, 188023198, 36124607, 1.0
 #gamma + jets samples, k = 1.26
 
 GJets_HT_100To200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_15Jan2019, GJets_DR-0p4_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8_v2.txt, Events, 5391.0, 15963435, 1702, 1.0
@@ -62,7 +62,7 @@ GJets_HT_600ToInf_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_
 
 #QCD
 # Ref. https://twiki.cern.ch/twiki/bin/viewauth/CMS/SummaryTable1G25ns#QCD. But numbers are from McM.                                                                            
-QCD_HT_100to200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_20Mar2019, QCD_HT100to200_TuneCP5_13TeV-madgraph-pythia8.txt, Events, 27990000, 52656237, 14915, 1.0
+QCD_HT_100to200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_20Mar2019, QCD_HT100to200_TuneCP5_13TeV-madgraph-pythia8.txt, Events, 27990000, 93267663, 14915, 1.0
 QCD_HT_200to300_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_15Jan2019, QCD_HT200to300_TuneCP5_13TeV-madgraph-pythia8.txt, Events, 1712000, 44403436, 25224, 1.0
 QCD_HT_300to500_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_20Mar2019, QCD_HT300to500_TuneCP5_13TeV-madgraph-pythia8.txt, Events, 347700, 60261123, 55454, 1.0
 QCD_HT_500to700_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_1Mar2019, QCD_HT500to700_TuneCP5_13TeV-madgraph-pythia8.txt, Events, 32100, 56498314, 83917, 1.0
@@ -143,9 +143,9 @@ WWW_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_
 # TODO: WWZ is not prodcued
 #WWZ_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/, WWZ_TuneCP5_13TeV-amcatnlo-pythia8.txt, Events, 0.1651, 235734, 14266, 1.0
 WZZ_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_15Jan2019, WZZ_TuneCP5_13TeV-amcatnlo-pythia8.txt, Events, 0.05565, 234830, 15170, 1.0
-ZZZ_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_15Jan2019, ZZZ_TuneCP5_13TeV-amcatnlo-pythia8.txt, Events, 0.01398, 231219, 17841, 1.0
+ZZZ_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_15Jan2019, ZZZ_TuneCP5_13TeV-amcatnlo-pythia8.txt, Events, 0.01398, 232159, 17841, 1.0
 WZG_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_15Jan2019, WZG_TuneCP5_13TeV-amcatnlo-pythia8.txt, Events, 0.04123, 920436, 79564, 1.0
-WWG_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_15Jan2019, WWG_TuneCP5_13TeV-amcatnlo-pythia8.txt, Events, 0.2147, 87931, 82589, 1.0
+WWG_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_15Jan2019, WWG_TuneCP5_13TeV-amcatnlo-pythia8.txt, Events, 0.2147, 879311, 82589, 1.0
 
 # ----------
 # - signal -
@@ -156,7 +156,7 @@ SMS_T1tttt_mGluino2000_mLSP100_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/St
 SMS_T1tttt_mGluino1200_mLSP800_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_20Mar2019, SMS-T1tttt_mGluino-1200_mLSP-800_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 0.0985, 147547, 0, 1.0
 SMS_T2tt_mStop_1200_mLSP_100_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_23Feb2019, SMS-T2tt_mStop-1200_mLSP-100_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 0.00170, 202760, 0, 1.0
 SMS_T2tt_mStop_650_mLSP_350_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_23Feb2019, SMS-T2tt_mStop-650_mLSP-350_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 0.125, 91673, 0, 1.0
-SMS_T2tt_mStop_1200_mLSP_100_TuneCP5_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_23Feb2019, SMS-T2tt_mStop-1200_mLSP-100_TuneCP5_13TeV-madgraphMLM-pythia8.txt, Events, 0.00170, 240713, 0, 1.0
+SMS_T2tt_mStop_1200_mLSP_100_TuneCP5_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_23Feb2019, SMS-T2tt_mStop-1200_mLSP-100_TuneCP5_13TeV-madgraphMLM-pythia8.txt, Events, 0.00170, 240713, 9679, 1.0
 SMS_T2tt_mStop_850_mLSP_100_TuneCP5_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_23Feb2019, SMS-T2tt_mStop-850_mLSP-100_TuneCP5_13TeV-madgraphMLM-pythia8.txt, Events, 0.0216, 245971, 2857, 1.0
 SMS_T2tt_mStop_650_mLSP_350_TuneCP5_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_23Feb2019, SMS-T2tt_mStop-650_mLSP-350_TuneCP5_13TeV-madgraphMLM-pythia8.txt, Events, 0.125, 98980, 460, 1.0
 SMS_T1bbbb_mGluino1000_mLSP900_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_20Mar2019, SMS-T1bbbb_mGluino-1000_mLSP-900_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 0.385, 154683, 0, 1.0
@@ -167,15 +167,15 @@ SMS_T2bW_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_9
 SMS_T2tb_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_23Feb2019, SMS-T2bt_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1, 37820378, 0, 1.0
 #SMS_T2tt_mStop_150_mLSP_250_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_23Feb2019, SMS-T2tt_mStop-150to250_TuneCP2_13TeV-madgraphMLM-pythia8_fastsim.txt, Events, 304, 33347161, 0, 1.0
 #SMS_T2tt_mStop_150_mLSP_250_ext1_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_23Feb2019, SMS-T2tt_mStop-150to250_TuneCP2_13TeV-madgraphMLM-pythia8_ext1_fastsim.txt, Events, 304, 50950452, 0, 1.0
-SMS_T2tt_mStop_350to400_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_20Mar2019, SMS-T2tt_mStop-350to400_TuneCP2_13TeV-madgraphMLM-pythia8.txt,  Events, 4.43,  33273481, 0, 1.0
+SMS_T2tt_mStop_350to400_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_20Mar2019, SMS-T2tt_mStop-350to400_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 4.43, 33273481, 0, 1.0
 #SMS_T2tt_mStop-400_mLSP-1200_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_23Feb2019, SMS-T2tt_mStop-400to1200_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 2.15, 36205404, 0, 1.0
 
-SMS_T2tt_mStop-1200to2000_fastsim_2017,  /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_20Mar2019, SMS-T2tt_mStop-1200to2000_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 18118595, 0, 1.0
+SMS_T2tt_mStop-1200to2000_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_20Mar2019, SMS-T2tt_mStop-1200to2000_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 18118595, 0, 1.0
 # T5ttcc
 #SMS_T5ttcc_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/, SMS-T5ttcc_TuneCP5_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 22422582, 0, 1.0
 
 # T5ttttDM175
-SMS_T5tttt_dM175_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_20Mar2019, SMS-T5tttt_dM175_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 14562709, 0, 1.0,
+SMS_T5tttt_dM175_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_20Mar2019, SMS-T5tttt_dM175_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 14562709, 22857507, 0, 1.0
 
 
 #Data
@@ -191,11 +191,11 @@ Data_SingleElectron_2017_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_producti
 Data_SingleElectron_2017_PeriodE, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PreProcessed_18Feb2019, SingleElectron/2017_Data_Run2017E-31Mar2018-v1.txt, Events, 9423, 1
 Data_SingleElectron_2017_PeriodF, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PreProcessed_18Feb2019, SingleElectron/2017_Data_Run2017F-31Mar2018-v1.txt, Events, 13567, 1
 
-Data_JetHT_2017_PeriodB, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PreProcessed_18Feb2019, JetHT/2017_Data_Run2017B-31Mar2018-v1.txt,  Events, 4793, 1
-Data_JetHT_2017_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PreProcessed_18Feb2019, JetHT/2017_Data_Run2017C-31Mar2018-v1.txt,  Events, 9755, 1
-Data_JetHT_2017_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PreProcessed_18Feb2019, JetHT/2017_Data_Run2017D-31Mar2018-v1.txt,  Events, 4320, 1
-Data_JetHT_2017_PeriodE, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PreProcessed_18Feb2019, JetHT/2017_Data_Run2017E-31Mar2018-v1.txt,  Events, 9423, 1
-Data_JetHT_2017_PeriodF, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PreProcessed_18Feb2019, JetHT/2017_Data_Run2017F-31Mar2018-v1.txt,  Events, 13563, 1
+Data_JetHT_2017_PeriodB, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PreProcessed_18Feb2019, JetHT/2017_Data_Run2017B-31Mar2018-v1.txt, Events, 4793, 1
+Data_JetHT_2017_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PreProcessed_18Feb2019, JetHT/2017_Data_Run2017C-31Mar2018-v1.txt, Events, 9755, 1
+Data_JetHT_2017_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PreProcessed_18Feb2019, JetHT/2017_Data_Run2017D-31Mar2018-v1.txt, Events, 4320, 1
+Data_JetHT_2017_PeriodE, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PreProcessed_18Feb2019, JetHT/2017_Data_Run2017E-31Mar2018-v1.txt, Events, 9423, 1
+Data_JetHT_2017_PeriodF, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PreProcessed_18Feb2019, JetHT/2017_Data_Run2017F-31Mar2018-v1.txt, Events, 13563, 1
 
 Data_SingleMuon_2017_PeriodB, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PreProcessed_18Feb2019, SingleMuon/2017_Data_Run2017B-31Mar2018-v1.txt, Events, 4793, 1
 Data_SingleMuon_2017_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PreProcessed_18Feb2019, SingleMuon/2017_Data_Run2017C-31Mar2018-v1.txt, Events, 9754, 1

--- a/sampleSets_PreProcessed_2018.cfg
+++ b/sampleSets_PreProcessed_2018.cfg
@@ -6,7 +6,7 @@ TTbar_HT_800to1200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn
 # 0.12 * kt
 TTbar_HT_1200to2500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019, TTJets_HT-1200to2500_TuneCP5_13TeV-madgraphMLM-pythia8.txt, Events, 0.19775, 2757645, 21782, 1.0
 # 0.00143 * kt
-TTbar_HT_2500toInf_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019, TTJets_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8.txt, Events, 0.00239, 1413798, 37306, 1.0
+TTbar_HT_2500toInf_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019, TTJets_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8.txt, Events, 0.00239, 1413797, 37307, 1.0
 
 # Calculated from PDG BRs'. Not from the kt * xSec in McM
 TTbarInc_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019, TTJets_TuneCP5_13TeV-madgraphMLM-pythia8.txt, Events, 831.76, 10239358, 4949, 1.0


### PR DESCRIPTION
Main changes
- Calculate n_events for 2016, 2017, 2018.
- Fix commas.

sampleSets_PreProcessed_2016.cfg
- number of events changed for these samples:
```
QCD_HT_500to700_2016 has 1 match(es) in nEvents file: old weights: (41193225, 0) new weights: (96208609, 0) ---  old and new weights are different
QCD_HT_700to1000_2016 has 1 match(es) in nEvents file: old weights: (36941498, 0) new weights: (37102917, 0) ---  old and new weights are different
TTGJets_2016 has 1 match(es) in nEvents file: old weights: (7695417, 3930555) new weights: (5483163, 2803717) ---  old and new weights are different
WWW_2016 has 1 match(es) in nEvents file: old weights: (0, 0) new weights: (225269, 14731) ---  old and new weights are different
WZZ_2016 has 1 match(es) in nEvents file: old weights: (0, 0) new weights: (231583, 15217) ---  old and new weights are different
```

sampleSets_PreProcessed_2017.cfg
- DYJetsToLL_HT_2500toInf_2017 missing comma
- SMS_T5tttt_dM175_fastsim_2017 has extra comma
- number of events changed for these samples:
```
DYJetsToLL_Inc_2017 has 1 match(es) in nEvents file: old weights: (49429380, 0) new weights: (188023198, 36124607) ---  old and new weights are different
QCD_HT_100to200_2017 has 1 match(es) in nEvents file: old weights: (52656237, 14915) new weights: (93267663, 14915) ---  old and new weights are different
ZZZ_2017 has 1 match(es) in nEvents file: old weights: (231219, 17841) new weights: (232159, 17841) ---  old and new weights are different
WWG_2017 has 1 match(es) in nEvents file: old weights: (87931, 82589) new weights: (879311, 82589) ---  old and new weights are different
SMS_T2tt_mStop_1200_mLSP_100_TuneCP5_fullsim_2017 has 1 match(es) in nEvents file: old weights: (240713, 0) new weights: (240713, 9679) ---  old and new weights are different
SMS_T5tttt_dM175_fastsim_2017 has 1 match(es) in nEvents file: old weights: (0, 1) new weights: (22857507, 0) ---  old and new weights are different
```

sampleSets_PreProcessed_2018.cfg
- number of events changed for these samples:
```
TTbar_HT_2500toInf_2018 has 1 match(es) in nEvents file: old weights: (1413798, 37306) new weights: (1413797, 37307) ---  old and new weights are different
```
- some text files are missing or have the wrong path which gives errors for some samples
```
WARNING: no matches found in nEvents file; TTbarSingleLepT_2018 has 0 matches
WARNING: no matches found in nEvents file; WJetsToLNu_Inc_2018 has 0 matches
WARNING: no matches found in nEvents file; ST_t_top_2018 has 0 matches
WARNING: no matches found in nEvents file; ST_tWnunu_2018 has 0 matches
WARNING: no matches found in nEvents file; GluGluHToZZTo4L_2018 has 0 matches
WARNING: no matches found in nEvents file; WZTo1L1Nu2Q_2018 has 0 matches
WARNING: no matches found in nEvents file; ZZTo4Q_2018 has 0 matches
WARNING: no matches found in nEvents file; WWZ_2018 has 0 matches

output_GluGluHToZZTo4L_2018.txt:ERROR: TypeError in getNEvts()
output_ST_tWnunu_2018.txt:ERROR: TypeError in getNEvts()
output_ST_t_top_2018.txt:ERROR: TypeError in getNEvts()
output_TTbarSingleLepT_2018.txt:ERROR: TypeError in getNEvts()
output_WJetsToLNu_Inc_2018.txt:ERROR: TypeError in getNEvts()
output_WWZ_2018.txt:ERROR: TypeError in getNEvts()
output_WZTo1L1Nu2Q_2018.txt:ERROR: TypeError in getNEvts()
output_WZ_2018.txt:ERROR: TypeError in getNEvts()
output_ZZTo4L_2018.txt:ERROR: TypeError in getNEvts()
output_ZZTo4Q_2018.txt:ERROR: TypeError in getNEvts()
```
Example of the error:
```
cmslpc35.fnal.gov submission_2019-04-23_10-48-51 # (NanoAOD) cat output/output_GluGluHToZZTo4L_2018.txt
Filelist not found:  root://cmseos.fnal.gov//store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC//GluGluHToZZTo4L_M125_13TeV_powheg2_JHUgenV6_pythia8.txt
files do not exist: getNEvts() returning None
ERROR: TypeError in getNEvts()
```