### PR TITLE
Number of events for pre-processed 2018

### DIFF
--- a/sampleSets_PreProcessed_2018.cfg
+++ b/sampleSets_PreProcessed_2018.cfg
@@ -2,7 +2,7 @@
 #1.61 * kt 
 TTbar_HT_600to800_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019, TTJets_HT-600to800_TuneCP5_13TeV-madgraphMLM-pythia8.txt, Events, 2.76, 14107298, 42096, 1.0
 # 0.663 * kt
-TTbar_HT_800to1200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019, TTJets_HT-800to1200_TuneCP5_13TeV-madgraphMLM-pythia8.txt, Events, 1.1156, 10323041, 45001, 1.0
+TTbar_HT_800to1200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019, TTJets_HT-800to1200_TuneCP5_13TeV-madgraphMLM-pythia8.txt, Events, 1.1156, 10327788, 45014, 1.0
 # 0.12 * kt
 TTbar_HT_1200to2500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019, TTJets_HT-1200to2500_TuneCP5_13TeV-madgraphMLM-pythia8.txt, Events, 0.19775, 2757645, 21782, 1.0
 # 0.00143 * kt
@@ -83,7 +83,7 @@ ST_tW_antitop_NoHad_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autum
 
 ST_s_lep_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019, ST_s-channel_4f_leptonDecays_TuneCP5_13TeV-madgraph-pythia8.txt, Events, 3.35, 32411561, 7505439, 1.0
 
-ST_t_top_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/, ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8.txt, Events, 136.065, 0, 0, 1.0 
+ST_t_top_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/, ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8.txt, Events, 136.065, 76558312, 2428688, 1.0
 
 ST_t_antitop_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019, ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8.txt, Events, 80.97, 76558312, 2428688, 1.0
 
@@ -144,7 +144,7 @@ ZZTo4L_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/P
 
 # Tri-boson: negative weights!
 WWW_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019, WWW_4F_TuneCP5_13TeV-amcatnlo-pythia8.txt, Events, 0.2086, 225050, 14950, 1.0
-WWZ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019, WWZ_TuneCP5_13TeV-amcatnlo-pythia8.txt, Events, 0.1651, 235734, 14266, 1.0
+WWZ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019, WWZ_TuneCP5_13TeV-amcatnlo-pythia8.txt, Events, 0.1651, 234955, 15045, 1.0
 WZZ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019, WZZ_TuneCP5_13TeV-amcatnlo-pythia8.txt, Events, 0.05565, 234625, 15375, 1.0
 ZZZ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019, ZZZ_TuneCP5_13TeV-amcatnlo-pythia8.txt, Events, 0.01398, 232141, 17859, 1.0
 WZG_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019, WZG_TuneCP5_13TeV-amcatnlo-pythia8.txt, Events, 0.04123, 1803922, 156078, 1.0
@@ -152,23 +152,23 @@ WWG_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreP
 
 ## For Data, using the 18Feb for Period D suggested by Scarlet
 ## TODO: Waiting for the processed Lumi from Scarlet
-Data_MET_2018_PeriodA,  /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/MET, 2018_Data_Run2018A-17Sep2018-v1.txt, Events, 58709.0, 1.0 
-Data_MET_2018_PeriodB,  /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/MET, 2018_Data_Run2018B-17Sep2018-v1.txt, Events, 58709.0, 1.0
-Data_MET_2018_PeriodC,  /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/MET, 2018_Data_Run2018C-17Sep2018-v1.txt, Events, 58709.0, 1.0
-Data_MET_2018_PeriodD,  /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_18Feb2019/MET, 2018_Data_Run2018D-PromptReco-v2.txt, Events, 58709.0, 1.0
+Data_MET_2018_PeriodA, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/MET, 2018_Data_Run2018A-17Sep2018-v1.txt, Events, 58709.0, 1.0
+Data_MET_2018_PeriodB, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/MET, 2018_Data_Run2018B-17Sep2018-v1.txt, Events, 58709.0, 1.0
+Data_MET_2018_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/MET, 2018_Data_Run2018C-17Sep2018-v1.txt, Events, 58709.0, 1.0
+Data_MET_2018_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_18Feb2019/MET, 2018_Data_Run2018D-PromptReco-v2.txt, Events, 58709.0, 1.0
 
-Data_JetHT_2018_PeriodA,  /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/JetHT, 2018_Data_Run2018A-17Sep2018-v1.txt, Events, 58709.0, 1.0
-Data_JetHT_2018_PeriodB,  /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/JetHT, 2018_Data_Run2018B-17Sep2018-v1.txt, Events, 58709.0, 1.0
-Data_JetHT_2018_PeriodC,  /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/JetHT, 2018_Data_Run2018C-17Sep2018-v1.txt, Events, 58709.0, 1.0
-Data_JetHT_2018_PeriodD,  /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_18Feb2019/JetHT, 2018_Data_Run2018D-PromptReco-v2.txt, Events, 58709.0, 1.0
+Data_JetHT_2018_PeriodA, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/JetHT, 2018_Data_Run2018A-17Sep2018-v1.txt, Events, 58709.0, 1.0
+Data_JetHT_2018_PeriodB, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/JetHT, 2018_Data_Run2018B-17Sep2018-v1.txt, Events, 58709.0, 1.0
+Data_JetHT_2018_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/JetHT, 2018_Data_Run2018C-17Sep2018-v1.txt, Events, 58709.0, 1.0
+Data_JetHT_2018_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_18Feb2019/JetHT, 2018_Data_Run2018D-PromptReco-v2.txt, Events, 58709.0, 1.0
 
-Data_EGamma_2018_PeriodA, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/EGamma, 2018_Data_Run2018A-17Sep2018-v2.txt, Events, 58709.0, 1.0 
-Data_EGamma_2018_PeriodB,  /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/EGamma, 2018_Data_Run2018B-17Sep2018-v1.txt, Events, 58709.0, 1.0
-Data_EGamma_2018_PeriodC,  /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/EGamma, 2018_Data_Run2018C-17Sep2018-v1.txt, Events, 58709.0, 1.0
-Data_EGamma_2018_PeriodD,  /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_18Feb2019/EGamma, 2018_Data_Run2018D-PromptReco-v2.txt, Events, 58709.0, 1.0
+Data_EGamma_2018_PeriodA, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/EGamma, 2018_Data_Run2018A-17Sep2018-v2.txt, Events, 58709.0, 1.0
+Data_EGamma_2018_PeriodB, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/EGamma, 2018_Data_Run2018B-17Sep2018-v1.txt, Events, 58709.0, 1.0
+Data_EGamma_2018_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/EGamma, 2018_Data_Run2018C-17Sep2018-v1.txt, Events, 58709.0, 1.0
+Data_EGamma_2018_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_18Feb2019/EGamma, 2018_Data_Run2018D-PromptReco-v2.txt, Events, 58709.0, 1.0
 
-Data_SingleMuon_2018_PeriodA,  /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/SingleMuon, 2018_Data_Run2018A-17Sep2018-v2.txt, Events, 58709.0, 1.0 
-Data_SingleMuon_2018_PeriodB,  /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/SingleMuon, 2018_Data_Run2018B-17Sep2018-v1.txt, Events, 58709.0, 1.0
-Data_SingleMuon_2018_PeriodC,  /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/SingleMuon, 2018_Data_Run2018C-17Sep2018-v1.txt, Events, 58709.0, 1.0
-Data_SingleMuon_2018_PeriodD,  /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_18Feb2019/SingleMuon, 2018_Data_Run2018D-PromptReco-v2.txt, Events, 58709.0, 1.0
+Data_SingleMuon_2018_PeriodA, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/SingleMuon, 2018_Data_Run2018A-17Sep2018-v2.txt, Events, 58709.0, 1.0
+Data_SingleMuon_2018_PeriodB, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/SingleMuon, 2018_Data_Run2018B-17Sep2018-v1.txt, Events, 58709.0, 1.0
+Data_SingleMuon_2018_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/SingleMuon, 2018_Data_Run2018C-17Sep2018-v1.txt, Events, 58709.0, 1.0
+Data_SingleMuon_2018_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_18Feb2019/SingleMuon, 2018_Data_Run2018D-PromptReco-v2.txt, Events, 58709.0, 1.0
 


### PR DESCRIPTION
Calculate number of events for pre-processed 2018.

Changes:
```
TTbar_HT_800to1200_2018 has 1 match(es) in nEvents file: old weights: (10323041, 45001) new weights: (10327788, 45014) ---  old and new weights are different
ST_t_top_2018 has 1 match(es) in nEvents file: old weights: (0, 0) new weights: (76558312, 2428688) ---  old and new weights are different
WWZ_2018 has 1 match(es) in nEvents file: old weights: (235734, 14266) new weights: (234955, 15045) ---  old and new weights are different
```