### PR TITLE
Fix ttbar_HT sample names

### DIFF
--- a/sampleCollections_2016.cfg
+++ b/sampleCollections_2016.cfg
@@ -7,7 +7,7 @@
 TTbar_2016, TTbarInc_2016
 TTbarSingleLep_2016, TTbarSingleLepT_2016, TTbarSingleLepTbar_2016
 TTbarDiLep_2016, TTbarDiLep_2016
-TTbarHT_2016, TTbar_HT-600to800_2016, TTbar_HT-800to1200_2016, TTbar_HT-1200to2500_2016, TTbar_HT-2500toInf_2016
+TTbarHT_2016, TTbar_HT_600to800_2016, TTbar_HT_800to1200_2016, TTbar_HT_1200to2500_2016, TTbar_HT_2500toInf_2016
 TTbarNoHad_2016, TTbarSingleLepT_2016, TTbarSingleLepTbar_2016, TTbarDiLep_2016
 
 WJetsToLNuInc_2016, WJetsToLNu_Inc_2016


### PR DESCRIPTION
The ttbar_HT sample names in `sampleCollections` have a dash but should have an underscore