### PR TITLE
Post processing v6 for 2017 and 2018

### DIFF
--- a/sampleSets_PostProcessed_2017.cfg
+++ b/sampleSets_PostProcessed_2017.cfg
@@ -8,254 +8,257 @@
 
 #TTbarInc has LO xsec on McM : 502.20 pb. The NNLO is 831.76 pb. The k-factor for ttbar is: kt = 831.76/502.20 ~ 1.656233
 #1.61 * kt 
-TTbar_HT_600to800_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v5, TTbar_HT_600to800_2017.txt, Events, 2.76, 81054027, 344742, 1.0
+TTbar_HT_600to800_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v6p1, TTbar_HT_600to800_2017.txt, Events, 2.76, 81054027, 344742, 1.0
 # 0.663 * kt
-TTbar_HT_800to1200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v5, TTbar_HT_800to1200_2017.txt, Events, 1.1156, 39743315, 244133, 1.0
+TTbar_HT_800to1200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v6, TTbar_HT_800to1200_2017.txt, Events, 1.1156, 39743315, 244133, 1.0
 # 0.12 * kt
-TTbar_HT_1200to2500_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v5, TTbar_HT_1200to2500_2017.txt, Events, 0.19775, 13067644, 147227, 1.0
+TTbar_HT_1200to2500_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v6p1, TTbar_HT_1200to2500_2017.txt, Events, 0.19775, 13067644, 147227, 1.0
 # 0.00143 * kt
-TTbar_HT_2500toInf_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, TTbar_HT_2500toInf_2017.txt, Events, 0.00239, 263220, 9349, 1.0
+TTbar_HT_2500toInf_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6p1, TTbar_HT_2500toInf_2017.txt, Events, 0.00239, 2787329, 99977, 1.0
 
 # Calculated from PDG BRs'. Not from the kt * xSec in McM
-TTbarInc_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, TTbarInc_2017.txt, Events, 831.76, 8021533, 4570, 1.0
+TTbarInc_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, TTbarInc_2017.txt, Events, 831.76, 8021533, 4570, 1.0
 
-TTbarDiLep_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, TTbarDiLep_2017.txt, Events, 87.315, 28364589, 15521, 1.0
+TTbarDiLep_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, TTbarDiLep_2017.txt, Events, 87.315, 28364589, 15521, 1.0
 
-TTbarSingleLepT_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, TTbarSingleLepT_2017.txt, Events, 182.17540224, 61726896, 34451, 1.0
-TTbarSingleLepTbar_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, TTbarSingleLepTbar_2017.txt, Events, 182.17540224, 39548166, 21706, 1.0
+TTbarSingleLepT_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, TTbarSingleLepT_2017.txt, Events, 182.17540224, 61726896, 34451, 1.0
+TTbarSingleLepTbar_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, TTbarSingleLepTbar_2017.txt, Events, 182.17540224, 39548166, 21706, 1.0
 
 # From https://twiki.cern.ch/twiki/bin/viewauth/CMS/SummaryTable1G25ns#W_jets, kw = 1.21
 # Duplicates
 #WJetsToLNu_Inc_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_15Jan2019, WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8.txt, Events, 61526.7, 72451101, 32313, 1.0
 
-WJetsToLNu_HT_70to100_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v5, WJetsToLNu_HT_70to100_2017.txt, Events, 1353, 22154485, 12662, 1.21
-WJetsToLNu_HT_100to200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, WJetsToLNu_HT_100to200_2017.txt, Events, 1345.0, 26870998, 21754, 1.21
-WJetsToLNu_HT_200to400_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, WJetsToLNu_HT_200to400_2017.txt, Events, 359.7, 21159521, 29068, 1.21
-WJetsToLNu_HT_400to600_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5p2p1, WJetsToLNu_HT_400to600_2017.txt, Events, 48.91, 5015181, 11084, 1.21
-WJetsToLNu_HT_600to800_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5p2p1, WJetsToLNu_HT_600to800_2017.txt, Events, 12.05, 10626974, 31378, 1.21
-WJetsToLNu_HT_800to1200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, WJetsToLNu_HT_800to1200_2017.txt, Events, 5.501, 15547216, 60980, 1.21
-WJetsToLNu_HT_1200to2500_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, WJetsToLNu_HT_1200to2500_2017.txt, Events, 1.329, 20125258, 133366, 1.21
-WJetsToLNu_HT_2500toInf_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, WJetsToLNu_HT_2500toInf_2017.txt, Events, 0.03216, 11193227, 230187, 1.21
+WJetsToLNu_HT_70to100_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v6p1, WJetsToLNu_HT_70to100_2017.txt, Events, 1353, 22154485, 12662, 1.21
+WJetsToLNu_HT_100to200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, WJetsToLNu_HT_100to200_2017.txt, Events, 1345.0, 26870998, 21754, 1.21
+WJetsToLNu_HT_200to400_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, WJetsToLNu_HT_200to400_2017.txt, Events, 359.7, 21159521, 29068, 1.21
+WJetsToLNu_HT_400to600_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, WJetsToLNu_HT_400to600_2017.txt, Events, 48.91, 5015181, 11084, 1.21
+WJetsToLNu_HT_600to800_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6p1, WJetsToLNu_HT_600to800_2017.txt, Events, 12.05, 10626974, 31378, 1.21
+WJetsToLNu_HT_800to1200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6p1, WJetsToLNu_HT_800to1200_2017.txt, Events, 5.501, 15547216, 60980, 1.21
+WJetsToLNu_HT_1200to2500_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, WJetsToLNu_HT_1200to2500_2017.txt, Events, 1.329, 20125258, 133366, 1.21
+WJetsToLNu_HT_2500toInf_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6p1, WJetsToLNu_HT_2500toInf_2017.txt, Events, 0.03216, 11193227, 230187, 1.21
 
 #Z -> nunu
 # From https://twiki.cern.ch/twiki/bin/viewauth/CMS/SummaryTable1G25ns#DY_Z, kz = 1.23
 
-ZJetsToNuNu_HT_100to200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, ZJetsToNuNu_HT_100to200_2017.txt, Events, 280.35, 22719867, 17399, 1.23
-ZJetsToNuNu_HT_200to400_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, ZJetsToNuNu_HT_200to400_2017.txt, Events, 77.67, 18330798, 24320, 1.23
-ZJetsToNuNu_HT_400to600_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5p2p1, ZJetsToNuNu_HT_400to600_2017.txt, Events, 10.73, 4139185, 8872, 1.23
-ZJetsToNuNu_HT_600to800_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5p2p1, ZJetsToNuNu_HT_600to800_2017.txt, Events, 2.559, 4013689, 11929, 1.23
-ZJetsToNuNu_HT_800to1200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, ZJetsToNuNu_HT_800to1200_2017.txt, Events, 1.1796, 2049928, 8149, 1.23
-ZJetsToNuNu_HT_1200to2500_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, ZJetsToNuNu_HT_1200to2500_2017.txt, Events, 0.28833, 338527, 2346, 1.23
-ZJetsToNuNu_HT_2500toInf_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, ZJetsToNuNu_HT_2500toInf_2017.txt, Events, 0.006945, 6590, 144, 1.23
+ZJetsToNuNu_HT_100to200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6p1, ZJetsToNuNu_HT_100to200_2017.txt, Events, 280.35, 22719867, 17399, 1.23
+ZJetsToNuNu_HT_200to400_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, ZJetsToNuNu_HT_200to400_2017.txt, Events, 77.67, 18330798, 24320, 1.23
+ZJetsToNuNu_HT_400to600_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, ZJetsToNuNu_HT_400to600_2017.txt, Events, 10.73, 4139185, 8872, 1.23
+ZJetsToNuNu_HT_600to800_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, ZJetsToNuNu_HT_600to800_2017.txt, Events, 2.559, 4013689, 11929, 1.23
+ZJetsToNuNu_HT_800to1200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6p1, ZJetsToNuNu_HT_800to1200_2017.txt, Events, 1.1796, 2049928, 8149, 1.23
+ZJetsToNuNu_HT_1200to2500_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, ZJetsToNuNu_HT_1200to2500_2017.txt, Events, 0.28833, 338527, 2346, 1.23
+ZJetsToNuNu_HT_2500toInf_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6p1, ZJetsToNuNu_HT_2500toInf_2017.txt, Events, 0.006945, 6590, 144, 1.23
 
 #DY->ll
 # kz = 1.23
-DYJetsToLL_HT_70to100_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, DYJetsToLL_HT_70to100_2017.txt, Events, 169.9, 9338790, 5247, 1.23
-DYJetsToLL_HT_100to200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, DYJetsToLL_HT_100to200_2017.txt, Events, 147.4, 11188807, 8681, 1.23
-DYJetsToLL_HT_200to400_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, DYJetsToLL_HT_200to400_2017.txt, Events, 40.99, 6667690, 9082, 1.23
-DYJetsToLL_HT_400to600_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, DYJetsToLL_HT_400to600_2017.txt, Events, 5.678, 7079042, 15604, 1.23
-DYJetsToLL_HT_600to800_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, DYJetsToLL_HT_600to800_2017.txt, Events, 1.367, 6674273, 19900, 1.23
-DYJetsToLL_HT_800to1200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, DYJetsToLL_HT_800to1200_2017.txt, Events, 0.6304, 3102346, 12634, 1.23
-DYJetsToLL_HT_1200to2500_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, DYJetsToLL_HT_1200to2500_2017.txt, Events, 0.1514, 95634, 676, 1.23
-DYJetsToLL_HT_2500toInf_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, DYJetsToLL_HT_2500toInf_2017.txt, Events, 0.003565, 410321, 8987, 1.23
+DYJetsToLL_HT_70to100_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, DYJetsToLL_HT_70to100_2017.txt, Events, 169.9, 9338790, 5247, 1.23
+DYJetsToLL_HT_100to200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, DYJetsToLL_HT_100to200_2017.txt, Events, 147.4, 11188807, 8681, 1.23
+DYJetsToLL_HT_200to400_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, DYJetsToLL_HT_200to400_2017.txt, Events, 40.99, 6667690, 9082, 1.23
+DYJetsToLL_HT_400to600_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, DYJetsToLL_HT_400to600_2017.txt, Events, 5.678, 7079042, 15604, 1.23
+DYJetsToLL_HT_600to800_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6p1, DYJetsToLL_HT_600to800_2017.txt, Events, 1.367, 6674273, 19900, 1.23
+DYJetsToLL_HT_800to1200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6p1, DYJetsToLL_HT_800to1200_2017.txt, Events, 0.6304, 3102346, 12634, 1.23
+DYJetsToLL_HT_1200to2500_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, DYJetsToLL_HT_1200to2500_2017.txt, Events, 0.1514, 95634, 676, 1.23
+DYJetsToLL_HT_2500toInf_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, DYJetsToLL_HT_2500toInf_2017.txt, Events, 0.003565, 410321, 8987, 1.23
 
 # NNLO 
 # To many Duplicate
 #DYJetsToLL_Inc_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_15Jan2019/, DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8.txt, Events, 6225.42, 188023198, 36124607, 1.0
 #gamma + jets samples, k = 1.26
 
-GJets_HT_100To200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v5, GJets_HT_100To200_2017.txt, Events, 5391.0, 15674364, 1674, 1.0
-GJets_HT_200To400_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v5, GJets_HT_200To400_2017.txt, Events, 1168.0, 49909914, 18123, 1.0
-GJets_HT_400To600_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v5, GJets_HT_400To600_2017.txt, Events, 132.5, 13378295, 11009, 1.0
-GJets_HT_600ToInf_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v5, GJets_HT_600ToInf_2017.txt, Events, 44.05, 8377065, 15816, 1.0
+GJets_HT_100To200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v6, GJets_HT_100To200_2017.txt, Events, 5391.0, 15674364, 1674, 1.0
+GJets_HT_200To400_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v6p1, GJets_HT_200To400_2017.txt, Events, 1168.0, 49909914, 18123, 1.0
+GJets_HT_400To600_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v6p1, GJets_HT_400To600_2017.txt, Events, 132.5, 13378295, 11009, 1.0
+GJets_HT_600ToInf_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v6, GJets_HT_600ToInf_2017.txt, Events, 44.05, 8377065, 15816, 1.0
 
 #QCD
 # Ref. https://twiki.cern.ch/twiki/bin/viewauth/CMS/SummaryTable1G25ns#QCD. But numbers are from McM.                                                                            
-QCD_HT_100to200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_20Mar2019_v5, QCD_HT_100to200_2017.txt, Events, 27990000, 93216894, 14907, 1.0
-QCD_HT_200to300_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v5, QCD_HT_200to300_2017.txt, Events, 1712000, 58900701, 33323, 1.0
-QCD_HT_300to500_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_20Mar2019_v5, QCD_HT_300to500_2017.txt, Events, 347700, 59227691, 54430, 1.0
-QCD_HT_500to700_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v5, QCD_HT_500to700_2017.txt, Events, 32100, 55983940, 83168, 1.0
-QCD_HT_700to1000_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v5, QCD_HT_700to1000_2017.txt, Events, 6831, 47621862, 102938, 1.0
-QCD_HT_1000to1500_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_20Mar2019_v5, QCD_HT_1000to1500_2017.txt, Events, 1207, 16826800, 56038, 1.0
-QCD_HT_1500to2000_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_20Mar2019_v5, QCD_HT_1500to2000_2017.txt, Events, 119.9, 11561686, 62872, 1.0
-QCD_HT_2000toInf_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_20Mar2019_v5, QCD_HT_2000toInf_2017.txt, Events, 25.24, 5879352, 57836, 1.0
+QCD_HT_100to200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_20Mar2019_v6, QCD_HT_100to200_2017.txt, Events, 27990000, 93216894, 14907, 1.0
+QCD_HT_200to300_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v6p1, QCD_HT_200to300_2017.txt, Events, 1712000, 58900701, 33323, 1.0
+QCD_HT_300to500_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_20Mar2019_v6, QCD_HT_300to500_2017.txt, Events, 347700, 59227691, 54430, 1.0
+QCD_HT_500to700_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v6p1, QCD_HT_500to700_2017.txt, Events, 32100, 55983940, 83168, 1.0
+QCD_HT_700to1000_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v6, QCD_HT_700to1000_2017.txt, Events, 6831, 47621862, 102938, 1.0
+QCD_HT_1000to1500_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_20Mar2019_v6p1, QCD_HT_1000to1500_2017.txt, Events, 1207, 16826800, 56038, 1.0
+QCD_HT_1500to2000_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_20Mar2019_v6, QCD_HT_1500to2000_2017.txt, Events, 119.9, 11561686, 62872, 1.0
+QCD_HT_2000toInf_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_20Mar2019_v6p1, QCD_HT_2000toInf_2017.txt, Events, 25.24, 5879352, 57836, 1.0
 
 #QCD
-# Ref. https://twiki.cern.ch/twiki/bin/viewauth/CMS/SummaryTable1G25ns#QCD. But numbers are from McM.                                                                            
-QCD_SMEARED_HT_100to200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_21Jan2020_v5, QCD_Smear_HT_100to200_2017.txt, Events, 27990000, 93216894, 14907, 1.0
-QCD_SMEARED_HT_200to300_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_21Jan2020_v5, QCD_Smear_HT_200to300_2017.txt, Events, 1712000, 58900701, 33323, 1.0
-QCD_SMEARED_HT_300to500_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_21Jan2020_v5, QCD_Smear_HT_300to500_2017.txt, Events, 347700, 59227691, 54430, 1.0
-QCD_SMEARED_HT_500to700_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_27Jan2020_v5, QCD_Smear_HT_500to700_2017.txt, Events, 32100, 55983940, 83168, 1.0
-QCD_SMEARED_HT_700to1000_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_21Jan2020_v5, QCD_Smear_HT_700to1000_2017.txt, Events, 6831, 47621862, 102938, 1.0
-QCD_SMEARED_HT_1000to1500_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_21Jan2020_v5, QCD_Smear_HT_1000to1500_2017.txt, Events, 1207, 16826800, 56038, 1.0
-QCD_SMEARED_HT_1500to2000_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_21Jan2020_v5, QCD_Smear_HT_1500to2000_2017.txt, Events, 119.9, 11561686, 62872, 1.0
-QCD_SMEARED_HT_2000toInf_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_21Jan2020_v5, QCD_Smear_HT_2000toInf_2017.txt, Events, 25.24, 5879352, 57836, 1.0
+# Special treatment for 2017 Smear QCD sample: Disable UpdateMETProducer("METFixEE2017")
+QCD_Smear_HT_100to200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_21Jan2020_v6, QCD_Smear_HT_100to200_2017.txt, Events, 27990000, 166923, 0, 1.0
+QCD_Smear_HT_200to300_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_21Jan2020_v6, QCD_Smear_HT_200to300_2017.txt, Events, 1712000, 131603, 176, 1.0
+QCD_Smear_HT_300to500_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_21Jan2020_v6, QCD_Smear_HT_300to500_2017.txt, Events, 347700, 331565, 401, 1.0
+QCD_Smear_HT_500to700_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_27Jan2020_v6, QCD_Smear_HT_500to700_2017.txt, Events, 32100, 2046967, 7945, 1.0
+QCD_Smear_HT_700to1000_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_21Jan2020_v6, QCD_Smear_HT_700to1000_2017.txt, Events, 6831, 8965471, 39276, 1.0
+QCD_Smear_HT_1000to1500_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_21Jan2020_v6, QCD_Smear_HT_1000to1500_2017.txt, Events, 1207, 12908433, 52780, 1.0
+QCD_Smear_HT_1500to2000_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_21Jan2020_v6, QCD_Smear_HT_1500to2000_2017.txt, Events, 119.9, 26947925, 159992, 1.0
+QCD_Smear_HT_2000toInf_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_21Jan2020_v6, QCD_Smear_HT_2000toInf_2017.txt, Events, 25.24, 31848116, 402917, 1.0
 
 #Other Samples
 # Aprox. NNLO
-ST_tW_top_incl_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, ST_tW_top_incl_2017.txt, Events, 35.85, 7907123, 30387, 1.0
-ST_tW_antitop_incl_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5p2p1, ST_tW_antitop_incl_2017.txt, Events, 35.85, 7715654, 29622, 1.0
+ST_tW_top_incl_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, ST_tW_top_incl_2017.txt, Events, 35.85, 7907123, 30387, 1.0
+ST_tW_antitop_incl_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, ST_tW_antitop_incl_2017.txt, Events, 35.85, 7715654, 29622, 1.0
 
-ST_tW_top_NoHad_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, ST_tW_top_NoHad_2017.txt, Events, 16.295, 4936171, 18931, 1.0
-ST_tW_antitop_NoHad_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, ST_tW_antitop_NoHad_2017.txt, Events, 16.295, 5614179, 21360, 1.0
+ST_tW_top_NoHad_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6p1, ST_tW_top_NoHad_2017.txt, Events, 16.295, 4936171, 18931, 1.0
+ST_tW_antitop_NoHad_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, ST_tW_antitop_NoHad_2017.txt, Events, 16.295, 5614179, 21360, 1.0
 #CAN USE gives more stats
 #ST_tW_antitop_NoHad_PSW_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_15Jan2019, ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_PSweights_13TeV-powheg-pythia8.txt, Events, 38.06, 4015366, 15530, 1.0
 
-ST_s_lep_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, ST_s_lep_2017.txt, Events, 3.36, 8025623, 1858182, 1.0
+ST_s_lep_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, ST_s_lep_2017.txt, Events, 3.36, 8025623, 1858182, 1.0
 #CAN USE gives more stats
 #ST_s_PSW_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_15Jan2019, ST_s-channel_4f_leptonDecays_TuneCP5_PSweights_13TeV-amcatnlo-pythia8.txt, Events, 10.32, 7870391, 1823313, 1.0
-ST_t_top_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, ST_t_top_2017.txt, Events, 136.065, 5982064, 0, 1.0
+ST_t_top_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, ST_t_top_2017.txt, Events, 136.065, 5982064, 0, 1.0
 
-ST_t_antitop_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, ST_t_antitop_2017.txt, Events, 80.97, 3675910, 0, 1.0
+ST_t_antitop_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, ST_t_antitop_2017.txt, Events, 80.97, 3675910, 0, 1.0
 
-tZq_ll_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, tZq_ll_2017.txt, Events, 0.0758, 8372025, 4904121, 1.0
+tZq_ll_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6p1, tZq_ll_2017.txt, Events, 0.0758, 8372025, 4904121, 1.0
 
-ST_tWll_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v5, ST_tWll_2017.txt, Events, 0.01104, 985845, 155, 1.0
-ST_tWnunu_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v5, ST_tWnunu_2017.txt, Events, 0.02122, 99986, 14, 1.0
+ST_tWll_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v6, ST_tWll_2017.txt, Events, 0.01104, 985845, 155, 1.0
+ST_tWnunu_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v6, ST_tWnunu_2017.txt, Events, 0.02122, 99986, 14, 1.0
 
 # NLO --> negative weights!
 # (sign of gen weight) * (lumi*xsec)/(effective number of events): effective number of events = N(evt) with positive weight - N(evt) with negative weight
-TTZToLLNuNu_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, TTZToLLNuNu_2017.txt, Events, 0.2529, 5567105, 1996385, 1.0
-TTZToQQ_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, TTZToQQ_2017.txt, Events, 0.5297, 553143, 196857, 1.0
+TTZToLLNuNu_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, TTZToLLNuNu_2017.txt, Events, 0.2529, 5567105, 1996385, 1.0
+TTZToQQ_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, TTZToQQ_2017.txt, Events, 0.5297, 553143, 196857, 1.0
 
 # NLO --> negative weights!
-TTWJetsToLNu_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, TTWJetsToLNu_2017.txt, Events, 0.2043, 3797523, 1111382, 1.0
-TTWJetsToQQ_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, TTWJetsToQQ_2017.txt, Events, 0.4062, 626433, 184873, 1.0
+TTWJetsToLNu_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, TTWJetsToLNu_2017.txt, Events, 0.2043, 3797523, 1111382, 1.0
+TTWJetsToQQ_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, TTWJetsToQQ_2017.txt, Events, 0.4062, 626433, 184873, 1.0
 
-TTTT_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, TTTT_2017.txt, Events, 0.009103, 686867, 313133, 1.0
+TTTT_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, TTTT_2017.txt, Events, 0.009103, 686867, 313133, 1.0
 
 # NLO --> negative weights!  
-TTGJets_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, TTGJets_2017.txt, Events, 3.697, 11165413, 4912975, 1.0
+TTGJets_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6p1, TTGJets_2017.txt, Events, 3.697, 11165413, 4912975, 1.0
 
 # ttH 
+##ttH, H-> bb: XS * BR = 0.5085 pb * 5.77E-01 = 0.2934 pb
+ttHTobb_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6p1, ttHTobb_2017.txt, Events, 0.2934, 5738448, 60205, 1.0
 
-ttHTobb_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, ttHTobb_2017.txt, Events, 0.153, 556912, 5688, 1.0
+ttHToNonbb_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, ttHToNonbb_2017.txt, Events, 0.215, 6403839, 61762, 1.0
 
-ttHToNonbb_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5p2p1, ttHToNonbb_2017.txt, Events, 0.215, 6403839, 61762, 1.0
-
-GluGluHToZZTo4L_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v5, GluGluHToZZTo4L_2017.txt, Events, 0.01212, 929403, 4841, 1.0
+GluGluHToZZTo4L_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v6, GluGluHToZZTo4L_2017.txt, Events, 0.01212, 929403, 4841, 1.0
 # VH --> negative weights!
 
-VHToNonbb_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, VHToNonbb_2017.txt, Events, 0.952, 684961, 233547, 1.0
+VHToNonbb_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, VHToNonbb_2017.txt, Events, 0.952, 684961, 233547, 1.0
 
 # Di-boson
 # Ref. https://indico.cern.ch/event/439995/session/0/contribution/6/attachments/1143460/1638648/diboson_final.pdf (NNLO is given)
-WWTo4Q_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, WWTo4Q_2017.txt, Events, 51.723, 1996201, 3799, 1.0
-WWTo2L2Nu_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, WWTo2L2Nu_2017.txt, Events, 12.178, 1996261, 3739, 1.0
-WWToLNuQQ_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, WWToLNuQQ_2017.txt, Events, 49.997, 8765939, 16586, 1.0
+WWTo4Q_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, WWTo4Q_2017.txt, Events, 51.723, 1996201, 3799, 1.0
+WWTo2L2Nu_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, WWTo2L2Nu_2017.txt, Events, 12.178, 1996261, 3739, 1.0
+WWToLNuQQ_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, WWToLNuQQ_2017.txt, Events, 49.997, 8765939, 16586, 1.0
 
 # Ref. https://twiki.cern.ch/twiki/bin/viewauth/CMS/SummaryTable1G25ns (NLO from MCFM)
 
-WZ_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, WZ_2017.txt, Events, 47.13, 3928630, 0, 1.0
-WZTo1L1Nu2Q_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, WZTo1L1Nu2Q_2017.txt, Events, 10.71, 15216736, 3869637, 1.0
-WZTo1L3Nu_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, WZTo1L3Nu_2017.txt, Events, 3.033, 3856153, 1138242, 1.0
-WZTo3LNu_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, WZTo3LNu_2017.txt, Events, 4.42965, 8923959, 2047015, 1.0
+WZ_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, WZ_2017.txt, Events, 47.13, 3928630, 0, 1.0
+WZTo1L1Nu2Q_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, WZTo1L1Nu2Q_2017.txt, Events, 10.71, 15216736, 3869637, 1.0
+WZTo1L3Nu_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, WZTo1L3Nu_2017.txt, Events, 3.033, 3856153, 1138242, 1.0
+WZTo3LNu_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, WZTo3LNu_2017.txt, Events, 4.42965, 8923959, 2047015, 1.0
 
-WZTo2L2Q_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v5, WZTo2L2Q_2017.txt, Events, 5.595, 22123387, 5458777, 1.0
+WZTo2L2Q_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v6, WZTo2L2Q_2017.txt, Events, 5.595, 22123387, 5458777, 1.0
 
-ZZTo2Q2Nu_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, ZZTo2Q2Nu_2017.txt, Events, 4.04, 28768932, 6507977, 1.0
-ZZTo2L2Nu_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, ZZTo2L2Nu_2017.txt, Events, 0.564, 8739213, 5555, 1.0
-ZZTo2L2Q_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, ZZTo2L2Q_2017.txt, Events, 3.22, 22804606, 5036312, 1.0
+ZZTo2Q2Nu_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, ZZTo2Q2Nu_2017.txt, Events, 4.04, 28768932, 6507977, 1.0
+ZZTo2L2Nu_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, ZZTo2L2Nu_2017.txt, Events, 0.564, 8739213, 5555, 1.0
+ZZTo2L2Q_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, ZZTo2L2Q_2017.txt, Events, 3.22, 22804606, 5036312, 1.0
 # TODO: ZZTo4Q_2017 is not produced!
 #ZZTo4Q_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/, ZZTo4Q_13TeV_amcatnloFXFX_madspin_pythia8.txt, Events, 6.912, 24647874, 5806353, 1.0
-ZZTo4L_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, ZZTo4L_2017.txt, Events, 1.212, 6928979, 35092, 1.0
+ZZTo4L_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, ZZTo4L_2017.txt, Events, 1.212, 6928979, 35092, 1.0
 
 # Tri-boson: negative weights!
-WWW_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, WWW_2017.txt, Events, 0.2086, 217773, 14527, 1.0
+WWW_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, WWW_2017.txt, Events, 0.2086, 217773, 14527, 1.0
 # TODO: WWZ is not prodcued
-WWZ_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v5, WWZ_2017.txt, Events, 0.1651, 234982, 15018, 1.0
-WZZ_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, WZZ_2017.txt, Events, 0.05565, 234830, 15170, 1.0
-ZZZ_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, ZZZ_2017.txt, Events, 0.01398, 232159, 17841, 1.0
-WZG_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, WZG_2017.txt, Events, 0.04123, 920436, 79564, 1.0
-WWG_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v5, WWG_2017.txt, Events, 0.2147, 879311, 82589, 1.0
+WWZ_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v6, WWZ_2017.txt, Events, 0.1651, 234982, 15018, 1.0
+WZZ_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, WZZ_2017.txt, Events, 0.05565, 234830, 15170, 1.0
+ZZZ_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, ZZZ_2017.txt, Events, 0.01398, 232159, 17841, 1.0
+WZG_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, WZG_2017.txt, Events, 0.04123, 920436, 79564, 1.0
+WWG_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6p1, WWG_2017.txt, Events, 0.2147, 879311, 82589, 1.0
 
 #----------
 #-corrido-
 #---------
-SMS_T2tt_mStop_250_mLSP_75_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v5, SMS_T2tt_mStop_250_mLSP_75_fullsim_2017.txt, Events, 24.8, 987074, 735, 1.0
-SMS_T2tt_mStop_250_mLSP_100_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v5, SMS_T2tt_mStop_250_mLSP_100_fullsim_2017.txt, Events, 24.8, 984812, 755, 1.0
-SMS_T2tt_mStop_250_mLSP_50_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v5, SMS_T2tt_mStop_250_mLSP_50_fullsim_2017.txt, Events, 24.8, 987611, 690, 1.0
-SMS_T2tt_mStop_175_mLSP_1_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v5, SMS_T2tt_mStop_175_mLSP_1_fullsim_2017.txt, Events, 146.0, 986331, 456, 1.0
+SMS_T2tt_mStop_250_mLSP_75_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v6, SMS_T2tt_mStop_250_mLSP_75_fullsim_2017.txt, Events, 24.8, 987074, 735, 1.0
+SMS_T2tt_mStop_250_mLSP_100_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v6, SMS_T2tt_mStop_250_mLSP_100_fullsim_2017.txt, Events, 24.8, 984812, 755, 1.0
+SMS_T2tt_mStop_250_mLSP_50_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v6, SMS_T2tt_mStop_250_mLSP_50_fullsim_2017.txt, Events, 24.8, 987611, 690, 1.0
+SMS_T2tt_mStop_175_mLSP_1_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v6, SMS_T2tt_mStop_175_mLSP_1_fullsim_2017.txt, Events, 146.0, 986331, 456, 1.0
 
 # ----------
 # - signal -
 # ----------
 
 
-SMS_T1tttt_mGluino2000_mLSP100_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_20Mar2019_v5, SMS_T1tttt_mGluino2000_mLSP100_fullsim_2017.txt, Events, 0.00101, 51480, 0, 1.0
-SMS_T1tttt_mGluino1200_mLSP800_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_20Mar2019_v5, SMS_T1tttt_mGluino1200_mLSP800_fullsim_2017.txt, Events, 0.0985, 147547, 0, 1.0
-SMS_T2tt_mStop_1200_mLSP_100_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_23Feb2019_v5, SMS_T2tt_mStop_1200_mLSP_100_fullsim_2017.txt, Events, 0.00170, 202760, 0, 1.0
-SMS_T2tt_mStop_650_mLSP_350_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_23Feb2019_v5, SMS_T2tt_mStop_650_mLSP_350_fullsim_2017.txt, Events, 0.125, 91673, 0, 1.0
-SMS_T2tt_mStop_1200_mLSP_100_TuneCP5_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_23Feb2019_v5, SMS_T2tt_mStop_1200_mLSP_100_TuneCP5_fullsim_2017.txt, Events, 0.00170, 240713, 9679, 1.0
-SMS_T2tt_mStop_850_mLSP_100_TuneCP5_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_23Feb2019_v5, SMS_T2tt_mStop_850_mLSP_100_TuneCP5_fullsim_2017.txt, Events, 0.0216, 245971, 2857, 1.0
-SMS_T2tt_mStop_650_mLSP_350_TuneCP5_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_23Feb2019_v5, SMS_T2tt_mStop_650_mLSP_350_TuneCP5_fullsim_2017.txt, Events, 0.125, 98980, 460, 1.0
-SMS_T1bbbb_mGluino1000_mLSP900_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_20Mar2019_v5, SMS_T1bbbb_mGluino1000_mLSP900_fullsim_2017.txt, Events, 0.385, 154683, 0, 1.0
-SMS_T1bbbb_mGluino1500_mLSP100_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_20Mar2019_v5, SMS_T1bbbb_mGluino1500_mLSP100_fullsim_2017.txt, Events, 0.0157, 47088, 0, 1.0
+SMS_T1tttt_mGluino2000_mLSP100_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_20Mar2019_v6, SMS_T1tttt_mGluino2000_mLSP100_fullsim_2017.txt, Events, 0.00101, 51480, 0, 1.0
+SMS_T1tttt_mGluino1200_mLSP800_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_20Mar2019_v6, SMS_T1tttt_mGluino1200_mLSP800_fullsim_2017.txt, Events, 0.0985, 147547, 0, 1.0
+SMS_T2tt_mStop_1200_mLSP_100_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_23Feb2019_v6, SMS_T2tt_mStop_1200_mLSP_100_fullsim_2017.txt, Events, 0.00170, 202760, 0, 1.0
+SMS_T2tt_mStop_650_mLSP_350_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_23Feb2019_v6, SMS_T2tt_mStop_650_mLSP_350_fullsim_2017.txt, Events, 0.125, 91673, 0, 1.0
+SMS_T2tt_mStop_1200_mLSP_100_TuneCP5_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_23Feb2019_v6, SMS_T2tt_mStop_1200_mLSP_100_TuneCP5_fullsim_2017.txt, Events, 0.00170, 240713, 9679, 1.0
+SMS_T2tt_mStop_850_mLSP_100_TuneCP5_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_23Feb2019_v6, SMS_T2tt_mStop_850_mLSP_100_TuneCP5_fullsim_2017.txt, Events, 0.0216, 245971, 2857, 1.0
+SMS_T2tt_mStop_650_mLSP_350_TuneCP5_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_23Feb2019_v6, SMS_T2tt_mStop_650_mLSP_350_TuneCP5_fullsim_2017.txt, Events, 0.125, 98980, 460, 1.0
+SMS_T1bbbb_mGluino1000_mLSP900_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_20Mar2019_v6, SMS_T1bbbb_mGluino1000_mLSP900_fullsim_2017.txt, Events, 0.385, 154683, 0, 1.0
+SMS_T1bbbb_mGluino1500_mLSP100_fullsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_20Mar2019_v6, SMS_T1bbbb_mGluino1500_mLSP100_fullsim_2017.txt, Events, 0.0157, 47088, 0, 1.0
 
-#SMS_T1bbbb_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v5, SMS_T1bbbb_fastsim_2017.txt, Events, 1.0, 82632610, 0, 1.0
-SMS_T1bbbb_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v4_fastsimv4, SMS_T1bbbb_fastsim_2017.txt, Events, 1.0, 82606248, 0, 1.0
+#SMS_T1bbbb_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_18Apr2019, SMS-T1bbbb_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 82632610, 0, 1.0
 
-#SMS_T1ttbb_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v5, SMS_T1ttbb_fastsim_2017.txt, Events, 1.0, 36666536, 0, 1.0
-SMS_T1ttbb_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v4_fastsimv4, SMS_T1ttbb_fastsim_2017.txt, Events, 1.0, 36666536, 0, 1.0
-SMS_T1tttt_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_fastsimv5_v5p1, SMS_T1tttt_fastsim_2017.txt, Events, 1.0, 89704153, 0, 1.0
-#SMS_T2bW_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_20Mar2019_v5, SMS_T2bW_fastsim_2017.txt, Events, 1.0, 34237029, 0, 1.0
-SMS_T2bW_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_20Mar2019_v4_fastsimv4, SMS_T2bW_fastsim_2017.txt, Events, 1.0, 34237029, 0, 1.0
+#SMS_T1ttbb_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_18Apr2019, SMS-T1ttbb_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 36666536, 0, 1.0
+SMS_T1ttbb_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_fastsimv5_v6, SMS_T1ttbb_fastsim_2017.txt, Events, 1.0, 36666536, 0, 1.0
+#SMS_T1tttt_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_18Apr2019, SMS-T1tttt_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 89704153, 0, 1.0
+SMS_T1tttt_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_fastsimv5_v6, SMS_T1tttt_fastsim_2017.txt, Events, 1.0, 89704153, 0, 1.0
+#SMS_T2bW_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_20Mar2019, SMS-T2bW_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 34237029, 0, 1.0
+SMS_T2bW_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_20Mar2019_fastsimv5_v6, SMS_T2bW_fastsim_2017.txt, Events, 1.0, 34237029, 0, 1.0
 
-#SMS_T2bWC_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v5, SMS_T2bWC_fastsim_2017.txt, Events, 1.0, 55923812, 0, 1.0
-SMS_T2bWC_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v4_fastsimv4, SMS_T2bWC_fastsim_2017.txt, Events, 1.0, 55923812, 0, 1.0
+#SMS_T2bWC_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_18Apr2019, SMS-T2bW_X05_dM-10to80_genHT-160_genMET-80_mWMin-0p1_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 55923812, 0, 1.0
+SMS_T2bWC_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_fastsimv5_v6, SMS_T2bWC_fastsim_2017.txt, Events, 1.0, 55923812, 0, 1.0
 
-SMS_T2fbd_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_fastsimv5_v5p1, SMS_T2fbd_fastsim_2017.txt, Events, 1.0, 114007895, 0, 1.0
+#SMS_T2fbd_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_18Apr2019, SMS-T2tt_dM-10to80_genHT-160_genMET-80_mWMin-0p1_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 114007895, 0, 1.0
+SMS_T2fbd_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_fastsimv5_v6, SMS_T2fbd_fastsim_2017.txt, Events, 1.0, 114007895, 0, 1.0
 
-#SMS_T2tb_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v5, SMS_T2tb_fastsim_2017.txt, Events, 1.0, 37700897, 0, 1.0
-SMS_T2tb_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v4_fastsimv4, SMS_T2tb_fastsim_2017.txt, Events, 1.0, 37700897, 0, 1.0
-##T2tt 150-200
-SMS_T2tt_mStop_150to250_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_fastsimv5_v5p1, SMS_T2tt_mStop_150to250_fastsim_2017.txt, Events, 1.0, 84451503, 0, 1.0
-SMS_T2tt_mStop_250to350_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_fastsimv5_v5p1, SMS_T2tt_mStop_250to350_fastsim_2017.txt, Events, 1.0, 90251662, 0, 1.0
-SMS_T2tt_mStop_350to400_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_fastsimv5_v5p1, SMS_T2tt_mStop_350to400_fastsim_2017.txt, Events, 1.0, 81393957, 0, 1.0
-SMS_T2tt_mStop_400to1200_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_fastsimv5_v5p1, SMS_T2tt_mStop_400to1200_fastsim_2017.txt, Events, 1.0, 89983565, 0, 1.0
-SMS_T2tt_mStop_1200to2000_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_fastsimv5_v5p1, SMS_T2tt_mStop_1200to2000_fastsim_2017.txt, Events, 1.0, 21748904, 0, 1.0
-## T5ttcc
-#SMS_T5ttcc_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v5, SMS_T5ttcc_fastsim_2017.txt, Events, 1.0, 29319856, 0, 1.0
-SMS_T5ttcc_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v4_fastsimv4, SMS_T5ttcc_fastsim_2017.txt, Events, 1.0, 29319856, 0, 1.0
+#SMS_T2tb_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_18Apr2019, SMS-T2bt_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 37700897, 0, 1.0
+SMS_T2tb_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_fastsimv5_v6, SMS_T2tb_fastsim_2017.txt, Events, 1.0, 37700897, 0, 1.0
+#T2tt 150-200
+#SMS_T2tt_mStop_150to250_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_18Apr2019, SMS-T2tt_mStop-150to250_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 84451503, 0, 1.0
+SMS_T2tt_mStop_150to250_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_fastsimv5_v6, SMS_T2tt_mStop_150to250_fastsim_2017.txt, Events, 1.0, 74715754, 0, 1.0
+#SMS_T2tt_mStop_250to350_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_18Apr2019, SMS-T2tt_mStop-250to350_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 90251662, 0, 1.0
+SMS_T2tt_mStop_250to350_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_fastsimv5_v6, SMS_T2tt_mStop_250to350_fastsim_2017.txt, Events, 1.0, 53297278, 0, 1.0
+#SMS_T2tt_mStop_350to400_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_18Apr2019, SMS-T2tt_mStop-350to400_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 81393957, 0, 1.0
+SMS_T2tt_mStop_350to400_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_fastsimv5_v6, SMS_T2tt_mStop_350to400_fastsim_2017.txt, Events, 1.0, 57528802, 0, 1.0
+#SMS_T2tt_mStop_400to1200_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_18Apr2019, SMS-T2tt_mStop-400to1200_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 89983565, 0, 1.0
+SMS_T2tt_mStop_400to1200_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_fastsimv5_v6, SMS_T2tt_mStop_400to1200_fastsim_2017.txt, Events, 1.0, 89983565, 0, 1.0
+#SMS_T2tt_mStop_1200to2000_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_18Apr2019, SMS-T2tt_mStop-1200to2000_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 21748904, 0, 1.0
+SMS_T2tt_mStop_1200to2000_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_fastsimv5_v6, SMS_T2tt_mStop_1200to2000_fastsim_2017.txt, Events, 1.0, 21748904, 0, 1.0
+# T5ttcc
+#SMS_T5ttcc_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_18Apr2019, SMS-T5ttcc_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 29319856, 0, 1.0
+SMS_T5ttcc_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_fastsimv5_v6, SMS_T5ttcc_fastsim_2017.txt, Events, 1.0, 29319856, 0, 1.0
+#SMS_T5ttcc_mGluino1750to2800_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_18Apr2019, SMS-T5ttcc_mGluino1750to2800_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 10964397, 0, 1.0
+SMS_T5ttcc_mGluino1750to2800_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_fastsimv5_v6, SMS_T5ttcc_mGluino1750to2800_fastsim_2017.txt, Events, 1.0, 10964397, 0, 1.0
+#T2cc
+#SMS_T2cc_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_18Apr2019, SMS-T2cc_genHT-160_genMET-80_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 31900270, 0, 1.0
+SMS_T2cc_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_fastsimv5_v6, SMS_T2cc_fastsim_2017.txt, Events, 1.0, 31900270, 0, 1.0
 
-#SMS_T5ttcc_mGluino1750to2800_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v5, SMS_T5ttcc_mGluino1750to2800_fastsim_2017.txt, Events, 1.0, 10964397, 0, 1.0
-SMS_T5ttcc_mGluino1750to2800_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v4_fastsimv4, SMS_T5ttcc_mGluino1750to2800_fastsim_2017.txt, Events, 1.0, 10964397, 0, 1.0
-##T2cc
-#SMS_T2cc_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v5, SMS_T2cc_fastsim_2017.txt, Events, 1.0, 31900270, 0, 1.0
-SMS_T2cc_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v4_fastsimv4, SMS_T2cc_fastsim_2017.txt, Events, 1.0, 31900270, 0, 1.0
-
-## T5ttttDM175
-#SMS_T5tttt_dM175_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v5, SMS_T5tttt_dM175_fastsim_2017.txt, Events, 1.0, 49518789, 0, 1.0
-SMS_T5tttt_dM175_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v4_fastsimv4, SMS_T5tttt_dM175_fastsim_2017.txt, Events, 1.0, 49518789, 0, 1.0
-##T2bb
-#SMS_T2bb_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v5, SMS_T2bb_fastsim_2017.txt, Events, 1.0, 59045878, 0, 1.0
-SMS_T2bb_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v4_fastsimv4, SMS_T2bb_fastsim_2017.txt, Events, 1.0, 59045878, 0, 1.0
-#SMS_T2bb_mSbot_1650to2600_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v5, SMS_T2bb_mSbot_1650to2600_fastsim_2017.txt, Events, 1.0, 15155776, 0, 1.0
-SMS_T2bb_mSbot_1650to2600_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v4_fastsimv4, SMS_T2bb_mSbot_1650to2600_fastsim_2017.txt, Events, 1.0, 15155776, 0, 1.0
+# T5ttttDM175
+#SMS_T5tttt_dM175_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_18Apr2019, SMS-T5tttt_dM175_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 49518789, 0, 1.0
+SMS_T5tttt_dM175_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_fastsimv5_v6, SMS_T5tttt_dM175_fastsim_2017.txt, Events, 1.0, 49518789, 0, 1.0
+#T2bb
+#SMS_T2bb_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_18Apr2019, SMS-T2bb_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 59045878, 0, 1.0
+#SMS_T2bb_mSbot_1650to2600_fastsim_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_18Apr2019, SMS-T2bb_mSbot-1650to2600_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 15155776, 0, 1.0
 
 # --- Data Syntax --- #
 # Sample name, directory for filelist, filename of filelist, TTree name, luminosity, k-factor (set to 1 for data)
 
-Data_MET_2017_PeriodB, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v5, Data_MET_2017_PeriodB.txt, Events, 4793.348, 1
-Data_MET_2017_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v5, Data_MET_2017_PeriodC.txt, Events, 9632.741, 1
-Data_MET_2017_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v5, Data_MET_2017_PeriodD.txt, Events, 4247.682, 1
-Data_MET_2017_PeriodE, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v5, Data_MET_2017_PeriodE.txt, Events, 9313.950, 1
-Data_MET_2017_PeriodF, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v5, Data_MET_2017_PeriodF.txt, Events, 13498.415, 1
+Data_MET_2017_PeriodB, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v6, Data_MET_2017_PeriodB.txt, Events, 4793.348, 1
+Data_MET_2017_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v6, Data_MET_2017_PeriodC.txt, Events, 9632.741, 1
+Data_MET_2017_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v6, Data_MET_2017_PeriodD.txt, Events, 4247.682, 1
+Data_MET_2017_PeriodE, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v6, Data_MET_2017_PeriodE.txt, Events, 9313.950, 1
+Data_MET_2017_PeriodF, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v6, Data_MET_2017_PeriodF.txt, Events, 13498.415, 1
 
-Data_SingleElectron_2017_PeriodB, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v5, Data_SingleElectron_2017_PeriodB.txt, Events, 4793.904, 1
-Data_SingleElectron_2017_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v5, Data_SingleElectron_2017_PeriodC.txt, Events, 9630.900, 1
-Data_SingleElectron_2017_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v5, Data_SingleElectron_2017_PeriodD.txt, Events, 4247.670, 1
-Data_SingleElectron_2017_PeriodE, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v5, Data_SingleElectron_2017_PeriodE.txt, Events, 9313.642, 1
-Data_SingleElectron_2017_PeriodF, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v5, Data_SingleElectron_2017_PeriodF.txt, Events, 13539.222, 1
+Data_SingleElectron_2017_PeriodB, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v6, Data_SingleElectron_2017_PeriodB.txt, Events, 4793.904, 1
+Data_SingleElectron_2017_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v6, Data_SingleElectron_2017_PeriodC.txt, Events, 9630.900, 1
+Data_SingleElectron_2017_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v6, Data_SingleElectron_2017_PeriodD.txt, Events, 4247.670, 1
+Data_SingleElectron_2017_PeriodE, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v6, Data_SingleElectron_2017_PeriodE.txt, Events, 9313.642, 1
+Data_SingleElectron_2017_PeriodF, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v6, Data_SingleElectron_2017_PeriodF.txt, Events, 13539.222, 1
 
-Data_SingleMuon_2017_PeriodB, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v5, Data_SingleMuon_2017_PeriodB.txt, Events, 4793.961, 1
-Data_SingleMuon_2017_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v5, Data_SingleMuon_2017_PeriodC.txt, Events, 9631.215, 1
-Data_SingleMuon_2017_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v5, Data_SingleMuon_2017_PeriodD.txt, Events, 4247.682, 1
-Data_SingleMuon_2017_PeriodE, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v5, Data_SingleMuon_2017_PeriodE.txt, Events, 9313.642, 1
-Data_SingleMuon_2017_PeriodF, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v5, Data_SingleMuon_2017_PeriodF.txt, Events, 13538.559, 1
+Data_SingleMuon_2017_PeriodB, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v6, Data_SingleMuon_2017_PeriodB.txt, Events, 4793.961, 1
+Data_SingleMuon_2017_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v6, Data_SingleMuon_2017_PeriodC.txt, Events, 9631.215, 1
+Data_SingleMuon_2017_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v6, Data_SingleMuon_2017_PeriodD.txt, Events, 4247.682, 1
+Data_SingleMuon_2017_PeriodE, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v6, Data_SingleMuon_2017_PeriodE.txt, Events, 9313.642, 1
+Data_SingleMuon_2017_PeriodF, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v6, Data_SingleMuon_2017_PeriodF.txt, Events, 13538.559, 1
 
-Data_SinglePhoton_2017_PeriodB, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v5, Data_SinglePhoton_2017_PeriodB.txt, Events, 4793.961, 1
-Data_SinglePhoton_2017_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v5, Data_SinglePhoton_2017_PeriodC.txt, Events, 9631.210, 1
-Data_SinglePhoton_2017_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v5, Data_SinglePhoton_2017_PeriodD.txt, Events, 4247.680, 1
-Data_SinglePhoton_2017_PeriodE, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v5, Data_SinglePhoton_2017_PeriodE.txt, Events, 9313.642, 1
-Data_SinglePhoton_2017_PeriodF, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v5, Data_SinglePhoton_2017_PeriodF.txt, Events, 13539.211, 1
+Data_SinglePhoton_2017_PeriodB, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v6, Data_SinglePhoton_2017_PeriodB.txt, Events, 4793.961, 1
+Data_SinglePhoton_2017_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v6, Data_SinglePhoton_2017_PeriodC.txt, Events, 9631.210, 1
+Data_SinglePhoton_2017_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v6, Data_SinglePhoton_2017_PeriodD.txt, Events, 4247.680, 1
+Data_SinglePhoton_2017_PeriodE, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v6, Data_SinglePhoton_2017_PeriodE.txt, Events, 9313.642, 1
+Data_SinglePhoton_2017_PeriodF, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_Mar_2018_NanAOD_Data/PostProcessed_14May2019_v6, Data_SinglePhoton_2017_PeriodF.txt, Events, 13539.211, 1

--- a/sampleSets_PostProcessed_2018.cfg
+++ b/sampleSets_PostProcessed_2018.cfg
@@ -8,234 +8,234 @@
 
 #TTbarInc has LO xsec on McM : 502.20 pb. The NNLO is 831.76 pb. The k-factor for ttbar is: kt = 831.76/502.20 ~ 1.656233
 #1.61 * kt 
-TTbar_HT_600to800_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, TTbar_HT_600to800_2018.txt, Events, 2.76, 14107298, 42096, 1.0
+TTbar_HT_600to800_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, TTbar_HT_600to800_2018.txt, Events, 2.76, 14107298, 42096, 1.0
 # 0.663 * kt
-TTbar_HT_800to1200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, TTbar_HT_800to1200_2018.txt, Events, 1.1156, 10327788, 45014, 1.0
+TTbar_HT_800to1200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, TTbar_HT_800to1200_2018.txt, Events, 1.1156, 10327788, 45014, 1.0
 # 0.12 * kt
-TTbar_HT_1200to2500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, TTbar_HT_1200to2500_2018.txt, Events, 0.19775, 2757645, 21782, 1.0
+TTbar_HT_1200to2500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, TTbar_HT_1200to2500_2018.txt, Events, 0.19775, 2757645, 21782, 1.0
 # 0.00143 * kt
-TTbar_HT_2500toInf_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, TTbar_HT_2500toInf_2018.txt, Events, 0.00239, 1413797, 37307, 1.0
+TTbar_HT_2500toInf_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, TTbar_HT_2500toInf_2018.txt, Events, 0.00239, 1413797, 37307, 1.0
 
 # Calculated from PDG BRs'. Not from the kt * xSec in McM
-TTbarInc_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, TTbarInc_2018.txt, Events, 831.76, 10239358, 4949, 1.0
+TTbarInc_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, TTbarInc_2018.txt, Events, 831.76, 10239358, 4949, 1.0
 
-TTbarDiLep_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, TTbarDiLep_2018.txt, Events, 87.315, 28687893, 13467, 1.0
+TTbarDiLep_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, TTbarDiLep_2018.txt, Events, 87.315, 28687893, 13467, 1.0
 
-TTbarSingleLepT_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, TTbarSingleLepT_2018.txt, Events, 182.17540224, 57150142, 27326, 1.0
-TTbarSingleLepTbar_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, TTbarSingleLepTbar_2018.txt, Events, 182.17540224, 59900645, 28560, 1.0
+TTbarSingleLepT_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, TTbarSingleLepT_2018.txt, Events, 182.17540224, 57150142, 27326, 1.0
+TTbarSingleLepTbar_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, TTbarSingleLepTbar_2018.txt, Events, 182.17540224, 59900645, 28560, 1.0
 
-WJetsToLNu_Inc_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_25Apr2019_v5, WJetsToLNu_Inc_2018.txt, Events, 61526.7, 70996650, 30211, 1.0
+WJetsToLNu_Inc_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_25Apr2019_v6, WJetsToLNu_Inc_2018.txt, Events, 61526.7, 70996650, 30211, 1.0
 
-WJetsToLNu_HT_70to100_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, WJetsToLNu_HT_70to100_2018.txt, Events, 1353, 28072273, 11971, 1.21
-WJetsToLNu_HT_100to200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, WJetsToLNu_HT_100to200_2018.txt, Events, 1345.0, 29504734, 16424, 1.21
-WJetsToLNu_HT_200to400_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, WJetsToLNu_HT_200to400_2018.txt, Events, 359.7, 25446044, 22889, 1.21
-WJetsToLNu_HT_400to600_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, WJetsToLNu_HT_400to600_2018.txt, Events, 48.91, 5924335, 8366, 1.21
-WJetsToLNu_HT_600to800_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, WJetsToLNu_HT_600to800_2018.txt, Events, 12.05, 19735538, 35756, 1.21
-WJetsToLNu_HT_800to1200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, WJetsToLNu_HT_800to1200_2018.txt, Events, 5.501, 8382457, 20230, 1.21
-WJetsToLNu_HT_1200to2500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, WJetsToLNu_HT_1200to2500_2018.txt, Events, 1.329, 7602766, 31183, 1.21
-WJetsToLNu_HT_2500toInf_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, WJetsToLNu_HT_2500toInf_2018.txt, Events, 0.03216, 3232796, 41184, 1.21
+WJetsToLNu_HT_70to100_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, WJetsToLNu_HT_70to100_2018.txt, Events, 1353, 28072273, 11971, 1.21
+WJetsToLNu_HT_100to200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, WJetsToLNu_HT_100to200_2018.txt, Events, 1345.0, 29504734, 16424, 1.21
+WJetsToLNu_HT_200to400_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, WJetsToLNu_HT_200to400_2018.txt, Events, 359.7, 25446044, 22889, 1.21
+WJetsToLNu_HT_400to600_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, WJetsToLNu_HT_400to600_2018.txt, Events, 48.91, 5924335, 8366, 1.21
+WJetsToLNu_HT_600to800_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, WJetsToLNu_HT_600to800_2018.txt, Events, 12.05, 19735538, 35756, 1.21
+WJetsToLNu_HT_800to1200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, WJetsToLNu_HT_800to1200_2018.txt, Events, 5.501, 8382457, 20230, 1.21
+WJetsToLNu_HT_1200to2500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, WJetsToLNu_HT_1200to2500_2018.txt, Events, 1.329, 7602766, 31183, 1.21
+WJetsToLNu_HT_2500toInf_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, WJetsToLNu_HT_2500toInf_2018.txt, Events, 0.03216, 3232796, 41184, 1.21
 
 #Z -> nunu
 # From https://twiki.cern.ch/twiki/bin/viewauth/CMS/SummaryTable1G25ns#DY_Z, kz = 1.23
 
-ZJetsToNuNu_HT_100to200_2018, /eos/uscms/store/group/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, ZJetsToNuNu_HT_100to200_2018.txt, Events, 280.35, 23690838, 12056, 1.23
-ZJetsToNuNu_HT_200to400_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, ZJetsToNuNu_HT_200to400_2018.txt, Events, 77.67, 23256510, 19836, 1.23
-ZJetsToNuNu_HT_400to600_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, ZJetsToNuNu_HT_400to600_2018.txt, Events, 10.73, 2696557, 3785, 1.23
-ZJetsToNuNu_HT_600to800_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, ZJetsToNuNu_HT_600to800_2018.txt, Events, 2.559, 5738491, 10484, 1.23
-ZJetsToNuNu_HT_800to1200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, ZJetsToNuNu_HT_800to1200_2018.txt, Events, 1.1796, 2061580, 5218, 1.23
-ZJetsToNuNu_HT_1200to2500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, ZJetsToNuNu_HT_1200to2500_2018.txt, Events, 0.28833, 341750, 1448, 1.23
-ZJetsToNuNu_HT_2500toInf_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, ZJetsToNuNu_HT_2500toInf_2018.txt, Events, 0.006945, 354986, 4653, 1.23
+ZJetsToNuNu_HT_100to200_2018, /eos/uscms/store/group/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, ZJetsToNuNu_HT_100to200_2018.txt, Events, 280.35, 23690838, 12056, 1.23
+ZJetsToNuNu_HT_200to400_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, ZJetsToNuNu_HT_200to400_2018.txt, Events, 77.67, 23256510, 19836, 1.23
+ZJetsToNuNu_HT_400to600_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, ZJetsToNuNu_HT_400to600_2018.txt, Events, 10.73, 2696557, 3785, 1.23
+ZJetsToNuNu_HT_600to800_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, ZJetsToNuNu_HT_600to800_2018.txt, Events, 2.559, 5738491, 10484, 1.23
+ZJetsToNuNu_HT_800to1200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, ZJetsToNuNu_HT_800to1200_2018.txt, Events, 1.1796, 2061580, 5218, 1.23
+ZJetsToNuNu_HT_1200to2500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, ZJetsToNuNu_HT_1200to2500_2018.txt, Events, 0.28833, 341750, 1448, 1.23
+ZJetsToNuNu_HT_2500toInf_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, ZJetsToNuNu_HT_2500toInf_2018.txt, Events, 0.006945, 354986, 4653, 1.23
 
 #DY->ll
 # kz = 1.23
-DYJetsToLL_HT_70to100_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, DYJetsToLL_HT_70to100_2018.txt, Events, 169.9, 10015512, 4172, 1.23
-DYJetsToLL_HT_100to200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, DYJetsToLL_HT_100to200_2018.txt, Events, 147.4, 11524320, 6190, 1.23
-DYJetsToLL_HT_200to400_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, DYJetsToLL_HT_200to400_2018.txt, Events, 40.99, 11216164, 9723, 1.23
-DYJetsToLL_HT_400to600_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, DYJetsToLL_HT_400to600_2018.txt, Events, 5.678, 36850411, 49275, 1.23
-DYJetsToLL_HT_600to800_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, DYJetsToLL_HT_600to800_2018.txt, Events, 1.367, 8845363, 16741, 1.23
-DYJetsToLL_HT_800to1200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, DYJetsToLL_HT_800to1200_2018.txt, Events, 0.6304, 3130052, 8077, 1.23
-DYJetsToLL_HT_1200to2500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, DYJetsToLL_HT_1200to2500_2018.txt, Events, 0.1514, 505408, 2216, 1.23
-DYJetsToLL_HT_2500toInf_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, DYJetsToLL_HT_2500toInf_2018.txt, Events, 0.003565, 421382, 5669, 1.23
+DYJetsToLL_HT_70to100_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, DYJetsToLL_HT_70to100_2018.txt, Events, 169.9, 10015512, 4172, 1.23
+DYJetsToLL_HT_100to200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, DYJetsToLL_HT_100to200_2018.txt, Events, 147.4, 11524320, 6190, 1.23
+DYJetsToLL_HT_200to400_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, DYJetsToLL_HT_200to400_2018.txt, Events, 40.99, 11216164, 9723, 1.23
+DYJetsToLL_HT_400to600_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, DYJetsToLL_HT_400to600_2018.txt, Events, 5.678, 36850411, 49275, 1.23
+DYJetsToLL_HT_600to800_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, DYJetsToLL_HT_600to800_2018.txt, Events, 1.367, 8845363, 16741, 1.23
+DYJetsToLL_HT_800to1200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, DYJetsToLL_HT_800to1200_2018.txt, Events, 0.6304, 3130052, 8077, 1.23
+DYJetsToLL_HT_1200to2500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, DYJetsToLL_HT_1200to2500_2018.txt, Events, 0.1514, 505408, 2216, 1.23
+DYJetsToLL_HT_2500toInf_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, DYJetsToLL_HT_2500toInf_2018.txt, Events, 0.003565, 421382, 5669, 1.23
 
 # NNLO
-DYJetsToLL_Inc_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, DYJetsToLL_Inc_2018.txt, Events, 6225.42, 100154500, 40097, 1.0
+DYJetsToLL_Inc_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, DYJetsToLL_Inc_2018.txt, Events, 6225.42, 100154500, 40097, 1.0
 
 #gamma + jets samples, k = 1.26
 # TODO: Missing HT_40to100, are we sure we don't need it?
-GJets_HT_100To200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, GJets_HT_100To200_2018.txt, Events, 5391.0, 15423890, 868, 1.0
-GJets_HT_200To400_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, GJets_HT_200To400_2018.txt, Events, 1168.0, 49447774, 9746, 1.0
-GJets_HT_400To600_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, GJets_HT_400To600_2018.txt, Events, 132.5, 13711819, 6166, 1.0
-GJets_HT_600ToInf_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, GJets_HT_600ToInf_2018.txt, Events, 44.05, 12444219, 12374, 1.0
+GJets_HT_100To200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, GJets_HT_100To200_2018.txt, Events, 5391.0, 15423890, 868, 1.0
+GJets_HT_200To400_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, GJets_HT_200To400_2018.txt, Events, 1168.0, 49447774, 9746, 1.0
+GJets_HT_400To600_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, GJets_HT_400To600_2018.txt, Events, 132.5, 13711819, 6166, 1.0
+GJets_HT_600ToInf_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, GJets_HT_600ToInf_2018.txt, Events, 44.05, 12444219, 12374, 1.0
 
 #QCD
 # Ref. https://twiki.cern.ch/twiki/bin/viewauth/CMS/SummaryTable1G25ns#QCD. But numbers are from McM.
-QCD_HT_100to200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, QCD_HT_100to200_2018.txt, Events, 27990000, 93962673, 9705, 1.0
-QCD_HT_200to300_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, QCD_HT_200to300_2018.txt, Events, 1712000, 54270554, 18888, 1.0
-QCD_HT_300to500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, QCD_HT_300to500_2018.txt, Events, 347700, 54631132, 30447, 1.0
-QCD_HT_500to700_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, QCD_HT_500to700_2018.txt, Events, 32100, 55104581, 48379, 1.0
-QCD_HT_700to1000_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, QCD_HT_700to1000_2018.txt, Events, 6831, 44002424, 54861, 1.0
-QCD_HT_1000to1500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, QCD_HT_1000to1500_2018.txt, Events, 1207, 15437011, 29214, 1.0
-QCD_HT_1500to2000_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, QCD_HT_1500to2000_2018.txt, Events, 119.9, 10921419, 33668, 1.0
-QCD_HT_2000toInf_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, QCD_HT_2000toInf_2018.txt, Events, 25.24, 5445111, 30566, 1.0
+QCD_HT_100to200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, QCD_HT_100to200_2018.txt, Events, 27990000, 93962673, 9705, 1.0
+QCD_HT_200to300_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, QCD_HT_200to300_2018.txt, Events, 1712000, 54270554, 18888, 1.0
+QCD_HT_300to500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, QCD_HT_300to500_2018.txt, Events, 347700, 54631132, 30447, 1.0
+QCD_HT_500to700_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, QCD_HT_500to700_2018.txt, Events, 32100, 55104581, 48379, 1.0
+QCD_HT_700to1000_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, QCD_HT_700to1000_2018.txt, Events, 6831, 44002424, 54861, 1.0
+QCD_HT_1000to1500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, QCD_HT_1000to1500_2018.txt, Events, 1207, 15437011, 29214, 1.0
+QCD_HT_1500to2000_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, QCD_HT_1500to2000_2018.txt, Events, 119.9, 10921419, 33668, 1.0
+QCD_HT_2000toInf_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, QCD_HT_2000toInf_2018.txt, Events, 25.24, 5445111, 30566, 1.0
 
 #QCD
-# Ref. https://twiki.cern.ch/twiki/bin/viewauth/CMS/SummaryTable1G25ns#QCD. But numbers are from McM.
-QCD_SMEARED_HT_100to200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_21Jan2020_v5, QCD_Smear_HT_100to200_2018.txt, Events, 27990000, 93962673, 9705, 1.0
-QCD_SMEARED_HT_200to300_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_21Jan2020_v5, QCD_Smear_HT_200to300_2018.txt, Events, 1712000, 54270554, 18888, 1.0
-QCD_SMEARED_HT_300to500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_21Jan2020_v5, QCD_Smear_HT_300to500_2018.txt, Events, 347700, 54631132, 30447, 1.0
-QCD_SMEARED_HT_500to700_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_21Jan2020_v5, QCD_Smear_HT_500to700_2018.txt, Events, 32100, 55104581, 48379, 1.0
-QCD_SMEARED_HT_700to1000_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_21Jan2020_v5, QCD_Smear_HT_700to1000_2018.txt, Events, 6831, 44002424, 54861, 1.0
-QCD_SMEARED_HT_1000to1500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_21Jan2020_v5, QCD_Smear_HT_1000to1500_2018.txt, Events, 1207, 15437011, 29214, 1.0
-QCD_SMEARED_HT_1500to2000_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_21Jan2020_v5, QCD_Smear_HT_1500to2000_2018.txt, Events, 119.9, 10921419, 33668, 1.0
-QCD_SMEARED_HT_2000toInf_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_21Jan2020_v5, QCD_Smear_HT_2000toInf_2018.txt, Events, 25.24, 5445111, 30566, 1.0
+# Special treatment for 2018 Smear QCD sample. Turn off reapplying JEC
+QCD_Smear_HT_100to200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6, QCD_Smear_HT_100to200_2018.txt, Events, 27990000, 93962673, 9705, 1.0
+QCD_Smear_HT_200to300_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6, QCD_Smear_HT_200to300_2018.txt, Events, 1712000, 54270554, 18888, 1.0
+QCD_Smear_HT_300to500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6, QCD_Smear_HT_300to500_2018.txt, Events, 347700, 54631132, 30447, 1.0
+QCD_Smear_HT_500to700_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6, QCD_Smear_HT_500to700_2018.txt, Events, 32100, 55104581, 48379, 1.0
+QCD_Smear_HT_700to1000_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6, QCD_Smear_HT_700to1000_2018.txt, Events, 6831, 44002424, 54861, 1.0
+QCD_Smear_HT_1000to1500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6, QCD_Smear_HT_1000to1500_2018.txt, Events, 1207, 15437011, 29214, 1.0
+QCD_Smear_HT_1500to2000_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6, QCD_Smear_HT_1500to2000_2018.txt, Events, 119.9, 10921419, 33668, 1.0
+QCD_Smear_HT_2000toInf_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6, QCD_Smear_HT_2000toInf_2018.txt, Events, 25.24, 5445111, 30566, 1.0
 
 #Other Samples
 # Aprox. NNLO
-ST_tW_top_incl_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, ST_tW_top_incl_2018.txt, Events, 35.85, 9575956, 22044, 1.0
-ST_tW_antitop_incl_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, ST_tW_antitop_incl_2018.txt, Events, 35.85, 7605590, 17410, 1.0
+ST_tW_top_incl_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, ST_tW_top_incl_2018.txt, Events, 35.85, 9575956, 22044, 1.0
+ST_tW_antitop_incl_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, ST_tW_antitop_incl_2018.txt, Events, 35.85, 7605590, 17410, 1.0
 
-ST_tW_top_NoHad_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, ST_tW_top_NoHad_2018.txt, Events, 16.295, 8702887, 19847, 1.0
-ST_tW_antitop_NoHad_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, ST_tW_antitop_NoHad_2018.txt, Events, 16.295, 6893932, 15883, 1.0
-
-
-ST_s_lep_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, ST_s_lep_2018.txt, Events, 3.36, 32411561, 7505439, 1.0
-
-ST_t_top_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_25Apr2019_v5, ST_t_top_2018.txt, Events, 136.065, 149201191, 5106409, 1.0
-
-ST_t_antitop_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, ST_t_antitop_2018.txt, Events, 80.97, 76558312, 2428688, 1.0
-
-tZq_ll_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, tZq_ll_2018.txt, Events, 0.0758, 8661895, 5074105, 1.0
+ST_tW_top_NoHad_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, ST_tW_top_NoHad_2018.txt, Events, 16.295, 8702887, 19847, 1.0
+ST_tW_antitop_NoHad_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, ST_tW_antitop_NoHad_2018.txt, Events, 16.295, 6893932, 15883, 1.0
 
 
-ST_tWll_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, ST_tWll_2018.txt, Events, 0.01104, 248565, 35, 1.0
+ST_s_lep_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, ST_s_lep_2018.txt, Events, 3.36, 32411561, 7505439, 1.0
 
-ST_tWnunu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_25Apr2019_v5, ST_tWnunu_2018.txt, Events, 0.02122, 99984, 16, 1.0
+ST_t_top_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_25Apr2019_v6, ST_t_top_2018.txt, Events, 136.065, 149201191, 5106409, 1.0
+
+ST_t_antitop_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, ST_t_antitop_2018.txt, Events, 80.97, 76558312, 2428688, 1.0
+
+tZq_ll_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, tZq_ll_2018.txt, Events, 0.0758, 8661895, 5074105, 1.0
+
+
+ST_tWll_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, ST_tWll_2018.txt, Events, 0.01104, 248565, 35, 1.0
+
+ST_tWnunu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_25Apr2019_v6, ST_tWnunu_2018.txt, Events, 0.02122, 99984, 16, 1.0
 
 # NLO --> negative weights!
 # (sign of gen weight) * (lumi*xsec)/(effective number of events): effective number of events = N(evt) with positive weight - N(evt) with negative weight
-TTZToLLNuNu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, TTZToLLNuNu_2018.txt, Events, 0.2529, 9746249, 3491751, 1.0
-TTZToQQ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, TTZToQQ_2018.txt, Events, 0.5297, 552613, 197387, 1.0
+TTZToLLNuNu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, TTZToLLNuNu_2018.txt, Events, 0.2529, 9746249, 3491751, 1.0
+TTZToQQ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, TTZToQQ_2018.txt, Events, 0.5297, 552613, 197387, 1.0
 
 # NLO --> negative weights!
-TTWJetsToLNu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, TTWJetsToLNu_2018.txt, Events, 0.2043, 3799018, 1112923, 1.0
-TTWJetsToQQ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, TTWJetsToQQ_2018.txt, Events, 0.4062, 646761, 188535, 1.0
+TTWJetsToLNu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, TTWJetsToLNu_2018.txt, Events, 0.2043, 3799018, 1112923, 1.0
+TTWJetsToQQ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, TTWJetsToQQ_2018.txt, Events, 0.4062, 646761, 188535, 1.0
 
-TTTT_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, TTTT_2018.txt, Events, 0.009103, 1620747, 738673, 1.0
+TTTT_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, TTTT_2018.txt, Events, 0.009103, 1620747, 738673, 1.0
 
 # NLO --> negative weights!  
-TTGJets_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, TTGJets_2018.txt, Events, 3.697, 3267151, 1424764, 1.0
+TTGJets_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, TTGJets_2018.txt, Events, 3.697, 3267151, 1424764, 1.0
 
 # ttH 
+#ttH, H-> bb: XS * BR = 0.5085 pb * 5.77E-01 = 0.2934 pb
+ttHTobb_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, ttHTobb_2018.txt, Events, 0.2934, 21193413, 222586, 1.0
 
-ttHTobb_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, ttHTobb_2018.txt, Events, 0.153, 21193413, 222586, 1.0
+ttHToNonbb_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, ttHToNonbb_2018.txt, Events, 0.215, 7447162, 78829, 1.0
 
-ttHToNonbb_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, ttHToNonbb_2018.txt, Events, 0.215, 7447162, 78829, 1.0
-
-GluGluHToZZTo4L_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, GluGluHToZZTo4L_2018.txt, Events, 0.01212, 953064, 4936, 1.0
+GluGluHToZZTo4L_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, GluGluHToZZTo4L_2018.txt, Events, 0.01212, 953064, 4936, 1.0
 # VH --> negative weights!
 
-VHToNonbb_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, VHToNonbb_2018.txt, Events, 0.952, 823097, 279481, 1.0
+VHToNonbb_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, VHToNonbb_2018.txt, Events, 0.952, 823097, 279481, 1.0
 
 # Di-boson
 # Ref. https://indico.cern.ch/event/439995/session/0/contribution/6/attachments/1143460/1638648/diboson_final.pdf (NNLO is given)
-WWTo4Q_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, WWTo4Q_2018.txt, Events, 51.723, 3801607, 7193, 1.0
-WWTo2L2Nu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, WWTo2L2Nu_2018.txt, Events, 12.178, 7744083, 14817, 1.0
-WWToLNuQQ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, WWToLNuQQ_2018.txt, Events, 49.997, 19163061, 36039, 1.0
+WWTo4Q_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, WWTo4Q_2018.txt, Events, 51.723, 3801607, 7193, 1.0
+WWTo2L2Nu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, WWTo2L2Nu_2018.txt, Events, 12.178, 7744083, 14817, 1.0
+WWToLNuQQ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, WWToLNuQQ_2018.txt, Events, 49.997, 19163061, 36039, 1.0
 
 # Ref. https://twiki.cern.ch/twiki/bin/viewauth/CMS/SummaryTable1G25ns (NLO from MCFM)
-WZ_AMC_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, WZ_AMC_2018.txt, Events, 47.13, 234955, 15045, 1.0
-WZ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, WZ_2018.txt, Events, 47.13, 3885000, 0, 1.0
+WZ_AMC_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, WZ_AMC_2018.txt, Events, 47.13, 234955, 15045, 1.0
+WZ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, WZ_2018.txt, Events, 47.13, 3885000, 0, 1.0
 # TODO: This is in production just last
 #WZTo1L1Nu2Q_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/, WZTo1L1Nu2Q, Events, 10.71, 15216736, 3869637, 1.0
-WZTo1L3Nu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, WZTo1L3Nu_2018.txt, Events, 3.033, 1305208, 384856, 1.0
-WZTo3LNu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, WZTo3LNu_2018.txt, Events, 4.42965, 1965924, 10676, 1.0
-WZTo3LNu_AMC_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, WZTo3LNu_AMC_2018.txt, Events, 4.42965, 9149138, 2099180, 1.0
-WZTo2L2Q_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_25Apr2019_v5, WZTo2L2Q_2018.txt, Events, 5.595, 22621041, 5572607, 1.0
+WZTo1L3Nu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, WZTo1L3Nu_2018.txt, Events, 3.033, 1305208, 384856, 1.0
+WZTo3LNu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, WZTo3LNu_2018.txt, Events, 4.42965, 1965924, 10676, 1.0
+WZTo3LNu_AMC_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, WZTo3LNu_AMC_2018.txt, Events, 4.42965, 9149138, 2099180, 1.0
+WZTo2L2Q_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_25Apr2019_v6, WZTo2L2Q_2018.txt, Events, 5.595, 22621041, 5572607, 1.0
 
-ZZTo2Q2Nu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, ZZTo2Q2Nu_2018.txt, Events, 4.04, 47090550, 10638442, 1.0
-ZZTo2L2Nu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, ZZTo2L2Nu_2018.txt, Events, 0.564, 8377176, 5424, 1.0
-ZZTo2L2Q_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, ZZTo2L2Q_2018.txt, Events, 3.22, 22857846, 5042623, 1.0
+ZZTo2Q2Nu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, ZZTo2Q2Nu_2018.txt, Events, 4.04, 47090550, 10638442, 1.0
+ZZTo2L2Nu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, ZZTo2L2Nu_2018.txt, Events, 0.564, 8377176, 5424, 1.0
+ZZTo2L2Q_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, ZZTo2L2Q_2018.txt, Events, 3.22, 22857846, 5042623, 1.0
 # TODO: This is not produced at all?
 #ZZTo4Q_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/, ZZTo4Q_13TeV_amcatnloFXFX_madspin_pythia8.txt, Events, 6.912, 24647874, 5806353, 1.0
-ZZTo4L_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, ZZTo4L_2018.txt, Events, 1.212, 6656071, 33829, 1.0
+ZZTo4L_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, ZZTo4L_2018.txt, Events, 1.212, 6656071, 33829, 1.0
 
 # Tri-boson: negative weights!
-WWW_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, WWW_2018.txt, Events, 0.2086, 225050, 14950, 1.0
-WWZ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, WWZ_2018.txt, Events, 0.1651, 234955, 15045, 1.0
-WZZ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, WZZ_2018.txt, Events, 0.05565, 234625, 15375, 1.0
-ZZZ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, ZZZ_2018.txt, Events, 0.01398, 232141, 17859, 1.0
-WZG_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, WZG_2018.txt, Events, 0.04123, 1803922, 156078, 1.0
-WWG_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, WWG_2018.txt, Events, 0.2147, 1140357, 109643, 1.0
+WWW_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, WWW_2018.txt, Events, 0.2086, 225050, 14950, 1.0
+WWZ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, WWZ_2018.txt, Events, 0.1651, 234955, 15045, 1.0
+WZZ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, WZZ_2018.txt, Events, 0.05565, 234625, 15375, 1.0
+ZZZ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, ZZZ_2018.txt, Events, 0.01398, 232141, 17859, 1.0
+WZG_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, WZG_2018.txt, Events, 0.04123, 1803922, 156078, 1.0
+WWG_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, WWG_2018.txt, Events, 0.2147, 1140357, 109643, 1.0
 
 #Singal samples
 
-SMS_T1tttt_mGluino2000_mLSP100_fullsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v5, SMS_T1tttt_mGluino2000_mLSP100_fullsim_2018.txt, Events, 0.00101, 77328, 0, 1.0
-SMS_T1tttt_mGluino1200_mLSP800_fullsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v5, SMS_T1tttt_mGluino1200_mLSP800_fullsim_2018.txt, Events, 0.0985, 225074, 0, 1.0
-SMS_T2tt_mStop_1200_mLSP_100_fullsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v5, SMS_T2tt_mStop_1200_mLSP_100_fullsim_2018.txt, Events, 0.00170, 362191, 0, 1.0
+SMS_T1tttt_mGluino2000_mLSP100_fullsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v6, SMS_T1tttt_mGluino2000_mLSP100_fullsim_2018.txt, Events, 0.00101, 77328, 0, 1.0
+SMS_T1tttt_mGluino1200_mLSP800_fullsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v6, SMS_T1tttt_mGluino1200_mLSP800_fullsim_2018.txt, Events, 0.0985, 225074, 0, 1.0
+SMS_T2tt_mStop_1200_mLSP_100_fullsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v6, SMS_T2tt_mStop_1200_mLSP_100_fullsim_2018.txt, Events, 0.00170, 362191, 0, 1.0
 #SMS_T2tt_mStop_650_mLSP_350_fullsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_28Apr2019, SMS-T2tt_mStop-650_mLSP-350_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 0.125, 91673, 0, 1.0
 #SMS_T1bbbb_mGluino1000_mLSP900_fullsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_28Apr2019, SMS-T1bbbb_mGluino-1000_mLSP-900_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 0.385, 154683, 0, 1.0
 #SMS_T1bbbb_mGluino1500_mLSP100_fullsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_28Apr2019, SMS-T1bbbb_mGluino-1500_mLSP-100_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 0.0157, 47088, 0, 1.0
 
 
 
-#SMS_T1bbbb_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_v5, SMS_T1bbbb_fastsim_2018.txt, Events, 1.0, 51149325, 0, 1.0
-SMS_T1bbbb_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_v4_fastsimv4, SMS_T1bbbb_fastsim_2018.txt, Events, 1.0, 51149325, 0, 1.0
-#SMS_T1ttbb_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_v5, SMS_T1ttbb_fastsim_2018.txt, Events, 1.0, 42767678, 0, 1.0
-SMS_T1ttbb_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_v4_fastsimv4, SMS_T1ttbb_fastsim_2018.txt, Events, 1.0, 41730907, 0, 1.0
-SMS_T1tttt_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v5p1, SMS_T1tttt_fastsim_2018.txt, Events, 1.0, 16062852, 0, 1.0
-#SMS_T2bW_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_v5, SMS_T2bW_fastsim_2018.txt, Events, 1.0, 49951254, 0, 1.0
-SMS_T2bW_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_v4_fastsimv4, SMS_T2bW_fastsim_2018.txt, Events, 1.0, 49951254, 0, 1.0
-#SMS_T2bWC_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v5, SMS_T2bWC_fastsim_2018.txt, Events, 1.0, 83515269, 0, 1.0
-SMS_T2bWC_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v4_fastsimv4, SMS_T2bWC_fastsim_2018.txt, Events, 1.0, 83515269, 0, 1.0
+#SMS_T1bbbb_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_26Apr2019, SMS-T1bbbb_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 51149325, 0, 1.0
+#SMS_T1ttbb_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_26Apr2019, SMS-T1ttbb_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 42767678, 0, 1.0
+#SMS_T1ttbb_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_26Apr2019_fastsimv5, SMS_T1ttbb_fastsim_2018.txt, Events, 1.0, 42729872, 0, 1.0
+#SMS_T1tttt_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_26Apr2019, SMS-T1tttt_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 16062852, 0, 1.0
+SMS_T1tttt_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6, SMS_T1tttt_fastsim_2018.txt, Events, 1.0, 13030646, 0, 1.0
+#SMS_T2bW_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_26Apr2019, SMS-T2bW_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 49951254, 0, 1.0
+SMS_T2bW_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6, SMS_T2bW_fastsim_2018.txt, Events, 1.0, 49951254, 0, 1.0
+#SMS_T2bWC_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_28Apr2019, SMS-T2bW_X05_dM-10to80_genHT-160_genMET-80_mWMin-0p1_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1, 83515269, 0, 1.0
+SMS_T2bWC_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_fastsimv5_v6, SMS_T2bWC_fastsim_2018.txt, Events, 1, 83515269, 0, 1.0
 
-SMS_T2fbd_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_fastsimv5_v5p1, SMS_T2fbd_fastsim_2018.txt, Events, 1, 70830917, 0, 1.0
+#SMS_T2fbd_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_28Apr2019, SMS-T2tt_dM-10to80_genHT-160_genMET-80_mWMin-0p1_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1, 70830917, 0, 1.0
+SMS_T2fbd_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_fastsimv5_v6, SMS_T2fbd_fastsim_2018.txt, Events, 1, 70830917, 0, 1.0
 
-#SMS_T2tb_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_v5, SMS_T2tb_fastsim_2018.txt, Events, 1.0, 56536237, 0, 1.0
-SMS_T2tb_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_v4_fastsimv4, SMS_T2tb_fastsim_2018.txt, Events, 1.0, 56536237, 0, 1.0
+#SMS_T2tb_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_26Apr2019, SMS-T2bt_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 56536237, 0, 1.0
+SMS_T2tb_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6, SMS_T2tb_fastsim_2018.txt, Events, 1.0, 56536237, 0, 1.0
 
 #T2tt 150-200
-SMS_T2tt_mStop_150to250_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v5p1, SMS_T2tt_mStop_150to250_fastsim_2018.txt, Events, 1.0, 50575010, 0, 1.0
-SMS_T2tt_mStop_250to350_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v5p1, SMS_T2tt_mStop_250to350_fastsim_2018.txt, Events, 1, 54453329, 0, 1.0
-SMS_T2tt_mStop_350to400_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v5p1, SMS_T2tt_mStop_350to400_fastsim_2018.txt, Events, 1, 49736815, 0, 1.0
-SMS_T2tt_mStop_400to1200_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v5p1, SMS_T2tt_mStop_400to1200_fastsim_2018.txt, Events, 1, 51959144, 0, 1.0
-SMS_T2tt_mStop_1200to2000_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v5p1, SMS_T2tt_mStop_1200to2000_fastsim_2018.txt, Events, 1.0, 13199684, 0, 1.0
+#SMS_T2tt_mStop_150to250_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_26Apr2019, SMS-T2tt_mStop-150to250_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 50575010, 0, 1.0
+SMS_T2tt_mStop_150to250_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6, SMS_T2tt_mStop_150to250_fastsim_2018.txt, Events, 1.0, 50575010, 0, 1.0
+#SMS_T2tt_mStop_250to350_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_26Apr2019, SMS-T2tt_mStop-250to350_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1, 54453329, 0, 1.0
+SMS_T2tt_mStop_250to350_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6, SMS_T2tt_mStop_250to350_fastsim_2018.txt, Events, 1, 54453329, 0, 1.0
+#SMS_T2tt_mStop_350to400_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_26Apr2019, SMS-T2tt_mStop-350to400_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1, 49736815, 0, 1.0
+SMS_T2tt_mStop_350to400_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6, SMS_T2tt_mStop_350to400_fastsim_2018.txt, Events, 1, 49736815, 0, 1.0
+#SMS_T2tt_mStop_400to1200_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_26Apr2019, SMS-T2tt_mStop-400to1200_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1, 51959144, 0, 1.0
+SMS_T2tt_mStop_400to1200_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6, SMS_T2tt_mStop_400to1200_fastsim_2018.txt, Events, 1, 51959144, 0, 1.0
+#SMS_T2tt_mStop_1200to2000_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_26Apr2019, SMS-T2tt_mStop-1200to2000_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 13199684, 0, 1.0
+SMS_T2tt_mStop_1200to2000_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6, SMS_T2tt_mStop_1200to2000_fastsim_2018.txt, Events, 1.0, 13199684, 0, 1.0
 # T5ttcc
-#SMS_T5ttcc_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_v5, SMS_T5ttcc_fastsim_2018.txt, Events, 1.0, 44077578, 0, 1.0
-SMS_T5ttcc_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_v4_fastsimv4, SMS_T5ttcc_fastsim_2018.txt, Events, 1.0, 44077578, 0, 1.0
-
-#SMS_T5ttcc_mGluino1750to2800_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_v5, SMS_T5ttcc_mGluino1750to2800_fastsim_2018.txt, Events, 1, 17437129, 0, 1.0
-SMS_T5ttcc_mGluino1750to2800_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_v4_fastsimv4, SMS_T5ttcc_mGluino1750to2800_fastsim_2018.txt, Events, 1, 17437129, 0, 1.0
+#SMS_T5ttcc_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_26Apr2019, SMS-T5ttcc_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 44077578, 0, 1.0
+#SMS_T5ttcc_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_26Apr2019_fastsimv5, SMS_T5ttcc_fastsim_2018.txt, Events, 1.0, 44005488, 0, 1.0
+#SMS_T5ttcc_mGluino1750to2800_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_26Apr2019, SMS-T5ttcc_mGluino1750to2800_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1, 17437129, 0, 1.0
+SMS_T5ttcc_mGluino1750to2800_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6, SMS_T5ttcc_mGluino1750to2800_fastsim_2018.txt, Events, 1, 17437129, 0, 1.0
 #T2cc
-#SMS_T2cc_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v5, SMS_T2cc_fastsim_2018.txt, Events, 1, 49922975, 0, 1
-SMS_T2cc_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v4_fastsimv4, SMS_T2cc_fastsim_2018.txt, Events, 1, 49922975, 0, 1
+#SMS_T2cc_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_28Apr2019, SMS-T2cc_genHT-160_genMET-80_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1, 49922975, 0, 1
+SMS_T2cc_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_fastsimv5_v6, SMS_T2cc_fastsim_2018.txt, Events, 1, 49922975, 0, 1
 
 # T5ttttDM175
-#SMS_T5tttt_dM175_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_v5, SMS_T5tttt_dM175_fastsim_2018.txt, Events, 1.0, 35185122, 0, 1.0
-SMS_T5tttt_dM175_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_v4_fastsimv4, SMS_T5tttt_dM175_fastsim_2018.txt, Events, 1.0, 35185122, 0, 1.0
+#SMS_T5tttt_dM175_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_26Apr2019, SMS-T5tttt_dM175_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 35185122, 0, 1.0
+SMS_T5tttt_dM175_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6, SMS_T5tttt_dM175_fastsim_2018.txt, Events, 1.0, 35185122, 0, 1.0
 #T2bb
-#SMS_T2bb_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_v5, SMS_T2bb_fastsim_2018.txt, Events, 1.0, 36164876, 0, 1
-SMS_T2bb_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_v4_fastsimv4, SMS_T2bb_fastsim_2018.txt, Events, 1.0, 36164876, 0, 1
-#SMS_T2bb_mSbot-1650to2600_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_v5, SMS_T2bb_mSbot-1650to2600_fastsim_2018.txt, Events, 1.0, 9338986, 0, 1.0
-SMS_T2bb_mSbot-1650to2600_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_v4_fastsimv4, SMS_T2bb_mSbot-1650to2600_fastsim_2018.txt, Events, 1.0, 9338986, 0, 1.0
+#SMS_T2bb_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_26Apr2019, SMS-T2bb_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 36164876, 0, 1
+#SMS_T2bb_mSbot-1650to2600_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_26Apr2019, SMS-T2bb_mSbot-1650to2600_TuneCP2_13TeV-madgraphMLM-pythia8.txt, Events, 1.0, 9338986, 0, 1.0
 
 # --- Data Syntax --- #
 # Sample name, directory for filelist, filename of filelist, TTree name, luminosity, k-factor (set to 1 for data)
 
-Data_MET_2018_PeriodA, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, Data_MET_2018_PeriodA.txt, Events, 14024.176, 1
-Data_MET_2018_PeriodB_PreHEM, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5_splitHEM, Data_MET_2018_PeriodB_PreHEM.txt, Events, 7044.4, 1
-Data_MET_2018_PeriodB_PostHEM, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5_splitHEM, Data_MET_2018_PeriodB_PostHEM.txt, Events, 16.6, 1
-Data_MET_2018_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, Data_MET_2018_PeriodC.txt, Events, 6894.782, 1
-Data_MET_2018_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, Data_MET_2018_PeriodD.txt, Events, 31719.531, 1
+Data_MET_2018_PeriodA, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, Data_MET_2018_PeriodA.txt, Events, 14024.176, 1
+Data_MET_2018_PeriodB, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, Data_MET_2018_PeriodB.txt, Events, 7060.764, 1
+Data_MET_2018_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, Data_MET_2018_PeriodC.txt, Events, 6894.782, 1
+Data_MET_2018_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, Data_MET_2018_PeriodD.txt, Events, 31719.531, 1
 
-Data_EGamma_2018_PeriodA, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v5, Data_EGamma_2018_PeriodA.txt, Events, 13697.621, 1
-Data_EGamma_2018_PeriodB_PreHEM, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5_splitHEM, Data_EGamma_2018_PeriodB_PreHEM.txt, Events, 7044.4, 1
-Data_EGamma_2018_PeriodB_PostHEM, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5_splitHEM, Data_EGamma_2018_PeriodB_PostHEM.txt, Events, 16.6, 1
-Data_EGamma_2018_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, Data_EGamma_2018_PeriodC.txt, Events, 6888.008, 1
-Data_EGamma_2018_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v5, Data_EGamma_2018_PeriodD.txt, Events, 31741.790, 1
+Data_EGamma_2018_PeriodA, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v6, Data_EGamma_2018_PeriodA.txt, Events, 13697.621, 1
+Data_EGamma_2018_PeriodB, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, Data_EGamma_2018_PeriodB.txt, Events, 7060.617, 1
+Data_EGamma_2018_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, Data_EGamma_2018_PeriodC.txt, Events, 6888.008, 1
+Data_EGamma_2018_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v6, Data_EGamma_2018_PeriodD.txt, Events, 31741.790, 1
 
-Data_SingleMuon_2018_PeriodA, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, Data_SingleMuon_2018_PeriodA.txt, Events, 14027.047, 1
-Data_SingleMuon_2018_PeriodB_PreHEM, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5_splitHEM, Data_SingleMuon_2018_PeriodB_PreHEM.txt, Events, 7044.4, 1
-Data_SingleMuon_2018_PeriodB_PostHEM, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5_splitHEM, Data_SingleMuon_2018_PeriodB_PostHEM.txt, Events, 16.6, 1
-Data_SingleMuon_2018_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v5, Data_SingleMuon_2018_PeriodC.txt, Events, 6894.771, 1
-Data_SingleMuon_2018_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v5, Data_SingleMuon_2018_PeriodD.txt, Events, 31742.979, 1
+Data_SingleMuon_2018_PeriodA, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, Data_SingleMuon_2018_PeriodA.txt, Events, 14027.047, 1
+Data_SingleMuon_2018_PeriodB, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, Data_SingleMuon_2018_PeriodB.txt, Events, 7060.622, 1
+Data_SingleMuon_2018_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6, Data_SingleMuon_2018_PeriodC.txt, Events, 6894.771, 1
+Data_SingleMuon_2018_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v6, Data_SingleMuon_2018_PeriodD.txt, Events, 31742.979, 1
 


### PR DESCRIPTION
Post processing v6 for 2017 and 2018. 
Note that the following samples still have ongoing work:

summary of 2017 samples with ongoing work:
- TTbar_HT_2500toInf_2017
- WJetsToLNu_HT_100to200_2017
- ST_tW_antitop_incl_2017

summary of 2018 samples with ongoing work:
- ttHToNonbb_2018
- ZJetsToNuNu_HT_1200to2500_2018