### PR TITLE
Post Processing v6: Update 2017 config file with rerun samples

### DIFF
--- a/sampleSets_PostProcessed_2017.cfg
+++ b/sampleSets_PostProcessed_2017.cfg
@@ -14,7 +14,7 @@ TTbar_HT_800to1200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17
 # 0.12 * kt
 TTbar_HT_1200to2500_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v6p1, TTbar_HT_1200to2500_2017.txt, Events, 0.19775, 13067644, 147227, 1.0
 # 0.00143 * kt
-TTbar_HT_2500toInf_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6p1, TTbar_HT_2500toInf_2017.txt, Events, 0.00239, 2787329, 99977, 1.0
+TTbar_HT_2500toInf_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6p1, TTbar_HT_2500toInf_2017.txt, Events, 0.00239, 3291669, 117923, 1.0
 
 # Calculated from PDG BRs'. Not from the kt * xSec in McM
 TTbarInc_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, TTbarInc_2017.txt, Events, 831.76, 8021533, 4570, 1.0
@@ -29,7 +29,7 @@ TTbarSingleLepTbar_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17
 #WJetsToLNu_Inc_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_15Jan2019, WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8.txt, Events, 61526.7, 72451101, 32313, 1.0
 
 WJetsToLNu_HT_70to100_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_25Apr2019_v6p1, WJetsToLNu_HT_70to100_2017.txt, Events, 1353, 22154485, 12662, 1.21
-WJetsToLNu_HT_100to200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, WJetsToLNu_HT_100to200_2017.txt, Events, 1345.0, 26870998, 21754, 1.21
+WJetsToLNu_HT_100to200_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6p1, WJetsToLNu_HT_100to200_2017.txt, Events, 1345.0, 26870998, 21754, 1.21
 WJetsToLNu_HT_200to400_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, WJetsToLNu_HT_200to400_2017.txt, Events, 359.7, 21159521, 29068, 1.21
 WJetsToLNu_HT_400to600_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, WJetsToLNu_HT_400to600_2017.txt, Events, 48.91, 5015181, 11084, 1.21
 WJetsToLNu_HT_600to800_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6p1, WJetsToLNu_HT_600to800_2017.txt, Events, 12.05, 10626974, 31378, 1.21
@@ -94,7 +94,7 @@ QCD_Smear_HT_2000toInf_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fa
 #Other Samples
 # Aprox. NNLO
 ST_tW_top_incl_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, ST_tW_top_incl_2017.txt, Events, 35.85, 7907123, 30387, 1.0
-ST_tW_antitop_incl_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, ST_tW_antitop_incl_2017.txt, Events, 35.85, 7715654, 29622, 1.0
+ST_tW_antitop_incl_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6p1, ST_tW_antitop_incl_2017.txt, Events, 35.85, 7715654, 29622, 1.0
 
 ST_tW_top_NoHad_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6p1, ST_tW_top_NoHad_2017.txt, Events, 16.295, 4936171, 18931, 1.0
 ST_tW_antitop_NoHad_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_15Jan2019_v6, ST_tW_antitop_NoHad_2017.txt, Events, 16.295, 5614179, 21360, 1.0


### PR DESCRIPTION
Update 2017 config file with rerun samples.

See issue: https://github.com/susy2015/StopCfg/issues/72

Updated samples with agreement in nEvents:
- TTbar_HT_2500toInf_2017
- WJetsToLNu_HT_100to200_2017
- ST_tW_antitop_incl_2017

Also ZJetsToNuNu_HT_1200to2500_2018 has agreement in nEvents. 