### PR TITLE
Updating the 2018 cfg list for the post post processing

### DIFF
--- a/sampleSets_PostProcessed_2018.cfg
+++ b/sampleSets_PostProcessed_2018.cfg
@@ -19,17 +19,17 @@ TTbar_HT_2500toInf_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn
 # Calculated from PDG BRs'. Not from the kt * xSec in McM
 TTbarInc_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, TTbarInc_2018.txt, Events, 831.76, 10239358, 4949, 1.0
 
-TTbarDiLep_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, TTbarDiLep_2018.txt, Events, 87.315, 28687893, 13467, 1.0
+TTbarDiLep_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5p1, TTbarDiLep_2018.txt, Events, 87.315, 28687893, 13467, 1.0
 
 TTbarSingleLepT_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, TTbarSingleLepT_2018.txt, Events, 182.17540224, 57150142, 27326, 1.0
-TTbarSingleLepTbar_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, TTbarSingleLepTbar_2018.txt, Events, 182.17540224, 59900645, 28560, 1.0
+TTbarSingleLepTbar_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5p1, TTbarSingleLepTbar_2018.txt, Events, 182.17540224, 59900645, 28560, 1.0
 
-WJetsToLNu_Inc_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_25Apr2019_v6_v6p5, WJetsToLNu_Inc_2018.txt, Events, 61526.7, 70996650, 30211, 1.0
+WJetsToLNu_Inc_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_25Apr2019_v6_v6p5p1, WJetsToLNu_Inc_2018.txt, Events, 61526.7, 70996650, 30211, 1.0
 
 WJetsToLNu_HT_70to100_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, WJetsToLNu_HT_70to100_2018.txt, Events, 1353, 28072273, 11971, 1.21
-WJetsToLNu_HT_100to200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, WJetsToLNu_HT_100to200_2018.txt, Events, 1345.0, 29504734, 16424, 1.21
-WJetsToLNu_HT_200to400_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, WJetsToLNu_HT_200to400_2018.txt, Events, 359.7, 25446044, 22889, 1.21
-WJetsToLNu_HT_400to600_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, WJetsToLNu_HT_400to600_2018.txt, Events, 48.91, 5924335, 8366, 1.21
+WJetsToLNu_HT_100to200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5p1, WJetsToLNu_HT_100to200_2018.txt, Events, 1345.0, 29504734, 16424, 1.21
+WJetsToLNu_HT_200to400_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5p1, WJetsToLNu_HT_200to400_2018.txt, Events, 359.7, 25446044, 22889, 1.21
+WJetsToLNu_HT_400to600_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5p1, WJetsToLNu_HT_400to600_2018.txt, Events, 48.91, 5924335, 8366, 1.21
 WJetsToLNu_HT_600to800_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, WJetsToLNu_HT_600to800_2018.txt, Events, 12.05, 19735538, 35756, 1.21
 WJetsToLNu_HT_800to1200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, WJetsToLNu_HT_800to1200_2018.txt, Events, 5.501, 8382457, 20230, 1.21
 WJetsToLNu_HT_1200to2500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, WJetsToLNu_HT_1200to2500_2018.txt, Events, 1.329, 7602766, 31183, 1.21
@@ -48,8 +48,8 @@ ZJetsToNuNu_HT_2500toInf_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/
 
 #DY->ll
 # kz = 1.23
-DYJetsToLL_HT_70to100_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, DYJetsToLL_HT_70to100_2018.txt, Events, 169.9, 10015512, 4172, 1.23
-DYJetsToLL_HT_100to200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, DYJetsToLL_HT_100to200_2018.txt, Events, 147.4, 11524320, 6190, 1.23
+DYJetsToLL_HT_70to100_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5p1, DYJetsToLL_HT_70to100_2018.txt, Events, 169.9, 10015512, 4172, 1.23
+DYJetsToLL_HT_100to200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5p1, DYJetsToLL_HT_100to200_2018.txt, Events, 147.4, 11524320, 6190, 1.23
 DYJetsToLL_HT_200to400_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, DYJetsToLL_HT_200to400_2018.txt, Events, 40.99, 11216164, 9723, 1.23
 DYJetsToLL_HT_400to600_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, DYJetsToLL_HT_400to600_2018.txt, Events, 5.678, 36850411, 49275, 1.23
 DYJetsToLL_HT_600to800_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, DYJetsToLL_HT_600to800_2018.txt, Events, 1.367, 8845363, 16741, 1.23
@@ -58,43 +58,43 @@ DYJetsToLL_HT_1200to2500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/
 DYJetsToLL_HT_2500toInf_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, DYJetsToLL_HT_2500toInf_2018.txt, Events, 0.003565, 421382, 5669, 1.23
 
 # NNLO
-DYJetsToLL_Inc_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, DYJetsToLL_Inc_2018.txt, Events, 6225.42, 100154500, 40097, 1.0
+DYJetsToLL_Inc_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5p1, DYJetsToLL_Inc_2018.txt, Events, 6225.42, 100154500, 40097, 1.0
 
 #gamma + jets samples, k = 1.26
 # TODO: Missing HT_40to100, are we sure we don't need it?
-GJets_HT_100To200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, GJets_HT_100To200_2018.txt, Events, 5391.0, 15423890, 868, 1.0
-GJets_HT_200To400_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, GJets_HT_200To400_2018.txt, Events, 1168.0, 49447774, 9746, 1.0
+GJets_HT_100To200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5p1, GJets_HT_100To200_2018.txt, Events, 5391.0, 15423890, 868, 1.0
+GJets_HT_200To400_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5p1, GJets_HT_200To400_2018.txt, Events, 1168.0, 49447774, 9746, 1.0
 GJets_HT_400To600_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, GJets_HT_400To600_2018.txt, Events, 132.5, 13711819, 6166, 1.0
 GJets_HT_600ToInf_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, GJets_HT_600ToInf_2018.txt, Events, 44.05, 12444219, 12374, 1.0
 
 #QCD
 # Ref. https://twiki.cern.ch/twiki/bin/viewauth/CMS/SummaryTable1G25ns#QCD. But numbers are from McM.
-QCD_HT_100to200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, QCD_HT_100to200_2018.txt, Events, 27990000, 93962673, 9705, 1.0
+QCD_HT_100to200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5p1, QCD_HT_100to200_2018.txt, Events, 27990000, 93962673, 9705, 1.0
 QCD_HT_200to300_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, QCD_HT_200to300_2018.txt, Events, 1712000, 54270554, 18888, 1.0
-QCD_HT_300to500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, QCD_HT_300to500_2018.txt, Events, 347700, 54631132, 30447, 1.0
+QCD_HT_300to500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5p1, QCD_HT_300to500_2018.txt, Events, 347700, 54631132, 30447, 1.0
 QCD_HT_500to700_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, QCD_HT_500to700_2018.txt, Events, 32100, 55104581, 48379, 1.0
-QCD_HT_700to1000_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, QCD_HT_700to1000_2018.txt, Events, 6831, 44002424, 54861, 1.0
+QCD_HT_700to1000_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5p1, QCD_HT_700to1000_2018.txt, Events, 6831, 44002424, 54861, 1.0
 QCD_HT_1000to1500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, QCD_HT_1000to1500_2018.txt, Events, 1207, 15437011, 29214, 1.0
 QCD_HT_1500to2000_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, QCD_HT_1500to2000_2018.txt, Events, 119.9, 10921419, 33668, 1.0
 QCD_HT_2000toInf_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, QCD_HT_2000toInf_2018.txt, Events, 25.24, 5445111, 30566, 1.0
 
 #QCD Smear: keep nEvents identical to QCD
 # Special treatment for 2018 Smear QCD sample. Turn off reapplying JEC
-QCD_Smear_HT_100to200_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6_v6p5, QCD_Smear_HT_100to200_2018.txt, Events, 27990000, 93962673, 9705, 1.0
-QCD_Smear_HT_200to300_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6_v6p5, QCD_Smear_HT_200to300_2018.txt, Events, 1712000, 54270554, 18888, 1.0
-QCD_Smear_HT_300to500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6_v6p5, QCD_Smear_HT_300to500_2018.txt, Events, 347700, 54631132, 30447, 1.0
-QCD_Smear_HT_500to700_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6_v6p5, QCD_Smear_HT_500to700_2018.txt, Events, 32100, 55104581, 48379, 1.0
-QCD_Smear_HT_700to1000_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6_v6p5, QCD_Smear_HT_700to1000_2018.txt, Events, 6831, 44002424, 54861, 1.0
-QCD_Smear_HT_1000to1500_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6_v6p5, QCD_Smear_HT_1000to1500_2018.txt, Events, 1207, 15437011, 29214, 1.0
-QCD_Smear_HT_1500to2000_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6_v6p5, QCD_Smear_HT_1500to2000_2018.txt, Events, 119.9, 10921419, 33668, 1.0
-QCD_Smear_HT_2000toInf_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6_v6p5, QCD_Smear_HT_2000toInf_2018.txt, Events, 25.24, 5445111, 30566, 1.0
+QCD_Smear_HT_100to200_2018,     /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6_v6p5, QCD_Smear_HT_100to200_2018.txt, Events, 27990000, 93962673, 9705, 1.0
+QCD_Smear_HT_200to300_2018,     /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6_v6p5, QCD_Smear_HT_200to300_2018.txt, Events, 1712000, 54270554, 18888, 1.0
+QCD_Smear_HT_300to500_2018,     /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6_v6p5, QCD_Smear_HT_300to500_2018.txt, Events, 347700, 54631132, 30447, 1.0
+QCD_Smear_HT_500to700_2018,     /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6_v6p5, QCD_Smear_HT_500to700_2018.txt, Events, 32100, 55104581, 48379, 1.0
+QCD_Smear_HT_700to1000_2018,    /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6_v6p5, QCD_Smear_HT_700to1000_2018.txt, Events, 6831, 44002424, 54861, 1.0
+QCD_Smear_HT_1000to1500_2018,   /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6_v6p5, QCD_Smear_HT_1000to1500_2018.txt, Events, 1207, 15437011, 29214, 1.0
+QCD_Smear_HT_1500to2000_2018,   /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6_v6p5, QCD_Smear_HT_1500to2000_2018.txt, Events, 119.9, 10921419, 33668, 1.0
+QCD_Smear_HT_2000toInf_2018,    /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6_v6p5, QCD_Smear_HT_2000toInf_2018.txt, Events, 25.24, 5445111, 30566, 1.0
 
 #Other Samples
 # Aprox. NNLO
 ST_tW_top_incl_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, ST_tW_top_incl_2018.txt, Events, 35.85, 9575956, 22044, 1.0
-ST_tW_antitop_incl_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, ST_tW_antitop_incl_2018.txt, Events, 35.85, 7605590, 17410, 1.0
+ST_tW_antitop_incl_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5p1, ST_tW_antitop_incl_2018.txt, Events, 35.85, 7605590, 17410, 1.0
 
-ST_tW_top_NoHad_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, ST_tW_top_NoHad_2018.txt, Events, 16.295, 8702887, 19847, 1.0
+ST_tW_top_NoHad_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5p1, ST_tW_top_NoHad_2018.txt, Events, 16.295, 8702887, 19847, 1.0
 ST_tW_antitop_NoHad_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, ST_tW_antitop_NoHad_2018.txt, Events, 16.295, 6893932, 15883, 1.0
 
 
@@ -102,9 +102,9 @@ ST_s_lep_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1
 
 ST_t_top_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_25Apr2019_v6_v6p5, ST_t_top_2018.txt, Events, 136.065, 149201191, 5106409, 1.0
 
-ST_t_antitop_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, ST_t_antitop_2018.txt, Events, 80.97, 76558312, 2428688, 1.0
+ST_t_antitop_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5p1, ST_t_antitop_2018.txt, Events, 80.97, 76558312, 2428688, 1.0
 
-tZq_ll_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, tZq_ll_2018.txt, Events, 0.0758, 8661895, 5074105, 1.0
+tZq_ll_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5p1, tZq_ll_2018.txt, Events, 0.0758, 8661895, 5074105, 1.0
 
 
 ST_tWll_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, ST_tWll_2018.txt, Events, 0.01104, 248565, 35, 1.0
@@ -113,7 +113,7 @@ ST_tWnunu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v
 
 # NLO --> negative weights!
 # (sign of gen weight) * (lumi*xsec)/(effective number of events): effective number of events = N(evt) with positive weight - N(evt) with negative weight
-TTZToLLNuNu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, TTZToLLNuNu_2018.txt, Events, 0.2529, 9746249, 3491751, 1.0
+TTZToLLNuNu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5p1, TTZToLLNuNu_2018.txt, Events, 0.2529, 9746249, 3491751, 1.0
 TTZToQQ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, TTZToQQ_2018.txt, Events, 0.5297, 552613, 197387, 1.0
 
 # NLO --> negative weights!
@@ -127,7 +127,7 @@ TTGJets_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/
 
 # ttH 
 #ttH, H-> bb: XS * BR = 0.5085 pb * 5.77E-01 = 0.2934 pb
-ttHTobb_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, ttHTobb_2018.txt, Events, 0.2934, 21193413, 222586, 1.0
+ttHTobb_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5p1, ttHTobb_2018.txt, Events, 0.2934, 21193413, 222586, 1.0
 
 ttHToNonbb_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, ttHToNonbb_2018.txt, Events, 0.215, 7447162, 78829, 1.0
 
@@ -150,7 +150,7 @@ WZ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostP
 WZTo1L3Nu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, WZTo1L3Nu_2018.txt, Events, 3.033, 1305208, 384856, 1.0
 WZTo3LNu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, WZTo3LNu_2018.txt, Events, 4.42965, 1965924, 10676, 1.0
 WZTo3LNu_AMC_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, WZTo3LNu_AMC_2018.txt, Events, 4.42965, 9149138, 2099180, 1.0
-WZTo2L2Q_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_25Apr2019_v6_v6p5, WZTo2L2Q_2018.txt, Events, 5.595, 22621041, 5572607, 1.0
+WZTo2L2Q_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_25Apr2019_v6_v6p5p1, WZTo2L2Q_2018.txt, Events, 5.595, 22621041, 5572607, 1.0
 
 ZZTo2Q2Nu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, ZZTo2Q2Nu_2018.txt, Events, 4.04, 47090550, 10638442, 1.0
 ZZTo2L2Nu_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, ZZTo2L2Nu_2018.txt, Events, 0.564, 8377176, 5424, 1.0
@@ -161,15 +161,15 @@ ZZTo4L_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/P
 
 # Tri-boson: negative weights!
 WWW_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, WWW_2018.txt, Events, 0.2086, 225050, 14950, 1.0
-WWZ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, WWZ_2018.txt, Events, 0.1651, 234955, 15045, 1.0
+WWZ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5p1, WWZ_2018.txt, Events, 0.1651, 234955, 15045, 1.0
 WZZ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, WZZ_2018.txt, Events, 0.05565, 234625, 15375, 1.0
 ZZZ_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, ZZZ_2018.txt, Events, 0.01398, 232141, 17859, 1.0
 WZG_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, WZG_2018.txt, Events, 0.04123, 1803922, 156078, 1.0
 WWG_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, WWG_2018.txt, Events, 0.2147, 1140357, 109643, 1.0
 
 ###########POWHEG
-TTToHadronic_powheg_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v6p2_v6p5, TTToHadronic_powheg_2018.txt, Events, 380.095, 133266791, 541209, 1.0
-TTToSemiLeptonic_powheg_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v6p2_v6p5, TTToSemiLeptonic_powheg_2018.txt, Events, 364.017888, 300259013, 1216985, 1.0
+#TTToHadronic_powheg_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v6p2_v6p5/, TTToHadronic_powheg_2018.txt, Events, 380.095, 133266791, 541209, 1.0
+#TTToSemiLeptonic_powheg_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v6p2_v6p5/, TTToSemiLeptonic_powheg_2018.txt, Events, 364.017888, 300259013, 1216985, 1.0
 #Singal samples
 
 SMS_T1tttt_mGluino2000_mLSP100_fullsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v6_v6p5, SMS_T1tttt_mGluino2000_mLSP100_fullsim_2018.txt, Events, 0.00101, 77328, 0, 1.0
@@ -186,30 +186,30 @@ SMS_T2tt_mStop_1200_mLSP_100_fullsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop
 #T1bbbb
 #SMS_T1bbbb_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_26Apr2019_fastsimv5, SMS_T1bbbb_fastsim_2018.txt, Events, 1.0, 51149325, 0, 1.0
 #T1ttbb
-SMS_T1ttbb_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5p1_v6p1_v6p5, SMS_T1ttbb_fastsim_2018.txt, Events, 1.0, 42729872, 0, 1.0
+#SMS_T1ttbb_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5p1_v6p1_v6p5p1, SMS_T1ttbb_fastsim_2018.txt, Events, 1.0, 42729872, 0, 1.0 
 #T1tttt
-SMS_T1tttt_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6p1_v6p5, SMS_T1tttt_fastsim_2018.txt, Events, 1.0, 16062852, 0, 1.0
+SMS_T1tttt_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6p1_v6p5p1, SMS_T1tttt_fastsim_2018.txt, Events, 1.0, 16062852, 0, 1.0
 #T2bW
 SMS_T2bW_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6p1_v6p5, SMS_T2bW_fastsim_2018.txt, Events, 1.0, 49951254, 0, 1.0
 #T2bWC
 SMS_T2bWC_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_fastsimv5_v6p1_v6p5, SMS_T2bWC_fastsim_2018.txt, Events, 1, 83515269, 0, 1.0
 #T2fbd
-SMS_T2fbd_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_fastsimv5_v6p1_v6p5, SMS_T2fbd_fastsim_2018.txt, Events, 1, 70830917, 0, 1.0
+SMS_T2fbd_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_fastsimv5_v6p1_v6p5p1, SMS_T2fbd_fastsim_2018.txt, Events, 1, 70830917, 0, 1.0
 #T2tb
 SMS_T2tb_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6p1_v6p5, SMS_T2tb_fastsim_2018.txt, Events, 1.0, 56536237, 0, 1.0
 #T2tt
 SMS_T2tt_mStop_150to250_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6p1_v6p5, SMS_T2tt_mStop_150to250_fastsim_2018.txt, Events, 1.0, 50575010, 0, 1.0
 SMS_T2tt_mStop_250to350_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6p1_v6p5, SMS_T2tt_mStop_250to350_fastsim_2018.txt, Events, 1, 54453329, 0, 1.0
 SMS_T2tt_mStop_350to400_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6p1_v6p5, SMS_T2tt_mStop_350to400_fastsim_2018.txt, Events, 1, 49736815, 0, 1.0
-SMS_T2tt_mStop_400to1200_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6p1_v6p5, SMS_T2tt_mStop_400to1200_fastsim_2018.txt, Events, 1, 51959144, 0, 1.0
-SMS_T2tt_mStop_1200to2000_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6p1_v6p5, SMS_T2tt_mStop_1200to2000_fastsim_2018.txt, Events, 1.0, 13199684, 0, 1.0
+#SMS_T2tt_mStop_400to1200_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6p1_v6p5, SMS_T2tt_mStop_400to1200_fastsim_2018.txt, Events, 1, 51959144, 0, 1.0
+SMS_T2tt_mStop_1200to2000_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6p1_v6p5p1, SMS_T2tt_mStop_1200to2000_fastsim_2018.txt, Events, 1.0, 13199684, 0, 1.0
 # T5ttcc
 SMS_T5ttcc_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5p1_v6p1_v6p5, SMS_T5ttcc_fastsim_2018.txt, Events, 1.0, 44005488, 0, 1.0
 SMS_T5ttcc_mGluino1750to2800_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6p1_v6p5, SMS_T5ttcc_mGluino1750to2800_fastsim_2018.txt, Events, 1, 17437129, 0, 1.0
 #T2cc
 SMS_T2cc_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_fastsimv5_v6p1_v6p5, SMS_T2cc_fastsim_2018.txt, Events, 1, 49922975, 0, 1
 # T5ttttDM175
-SMS_T5tttt_dM175_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6p1_v6p5, SMS_T5tttt_dM175_fastsim_2018.txt, Events, 1.0, 35185122, 0, 1.0
+SMS_T5tttt_dM175_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6p1_v6p5p1, SMS_T5tttt_dM175_fastsim_2018.txt, Events, 1.0, 35185122, 0, 1.0
 #T2bb
 #SMS_T2bb_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_26Apr2019_fastsimv5, SMS_T2bb_fastsim_2018.txt, Events, 1.0, 36164876, 0, 1
 #SMS_T2bb_mSbot_1650to2600_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_26Apr2019_fastsimv5, SMS_T2bb_mSbot_1650to2600_fastsim_2018.txt, Events, 1.0, 9338986, 0, 1.0
@@ -218,7 +218,7 @@ SMS_T5tttt_dM175_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/
 # --- Data Syntax --- #
 # Sample name, directory for filelist, filename of filelist, TTree name, luminosity, k-factor (set to 1 for data)
 
-Data_MET_2018_PeriodA, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, Data_MET_2018_PeriodA.txt, Events, 14024.176, 1
+Data_MET_2018_PeriodA, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5p1, Data_MET_2018_PeriodA.txt, Events, 14024.176, 1
 Data_MET_2018_PeriodB, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, Data_MET_2018_PeriodB.txt, Events, 7060.764, 1
 Data_MET_2018_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, Data_MET_2018_PeriodC.txt, Events, 6894.782, 1
 Data_MET_2018_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, Data_MET_2018_PeriodD.txt, Events, 31719.531, 1
@@ -226,10 +226,10 @@ Data_MET_2018_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18
 Data_EGamma_2018_PeriodA, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v6_v6p5, Data_EGamma_2018_PeriodA.txt, Events, 13697.621, 1
 Data_EGamma_2018_PeriodB, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, Data_EGamma_2018_PeriodB.txt, Events, 7060.617, 1
 Data_EGamma_2018_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, Data_EGamma_2018_PeriodC.txt, Events, 6888.008, 1
-Data_EGamma_2018_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v6_v6p5, Data_EGamma_2018_PeriodD.txt, Events, 31741.790, 1
+Data_EGamma_2018_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v6_v6p5p1, Data_EGamma_2018_PeriodD.txt, Events, 31741.790, 1
 
-Data_SingleMuon_2018_PeriodA, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, Data_SingleMuon_2018_PeriodA.txt, Events, 14027.047, 1
-Data_SingleMuon_2018_PeriodB, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, Data_SingleMuon_2018_PeriodB.txt, Events, 7060.622, 1
+#Data_SingleMuon_2018_PeriodA, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, Data_SingleMuon_2018_PeriodA.txt, Events, 14027.047, 1
+Data_SingleMuon_2018_PeriodB, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5p1, Data_SingleMuon_2018_PeriodB.txt, Events, 7060.622, 1
 Data_SingleMuon_2018_PeriodC, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_22March2019_v6_v6p5, Data_SingleMuon_2018_PeriodC.txt, Events, 6894.771, 1
-Data_SingleMuon_2018_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v6_v6p5, Data_SingleMuon_2018_PeriodD.txt, Events, 31742.979, 1
+Data_SingleMuon_2018_PeriodD, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_v6_v6p5p1, Data_SingleMuon_2018_PeriodD.txt, Events, 31742.979, 1
 


### PR DESCRIPTION
The comparison between updateSamples.py is
ERROR for QCD_Smear_HT_1500to2000_2018: 1 matches found (should be exactly 2)
ERROR for TTToHadronic_powheg_2018: 1 matches found (should be exactly 2)
ERROR for TTToSemiLeptonic_powheg_2018: 0 matches found (should be exactly 2)
ERROR for SMS_T1ttbb_fastsim_2018: 1 matches found (should be exactly 2)
ERROR for SMS_T2tt_mStop_400to1200_fastsim_2018 matches found (should be exactly 2)
The QCD pre post processed seems to have an issue with nEvents not sure why but the postpost nevents is
QCD_Smear_HT_1500to2000_2018, root://cmseos.fnal.gov//store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_29Feb2020_v6_v6p5/QCD_Smear_HT_1500to2000_2018.txt, Positive weights: 22228782, Negative weights: 73809
I commented out the Powheg samples.
The last two signals have a missing submission and a corrupt file only one/two mass point that are currently running.
SMS_T1ttbb_mGluino2304_mLSP400_fastsim_2018.root
SMS_T1ttbb_mGluino2304_mLSP500_fastsim_2018.root
SMS_T2tt_mStop417_mLSP250_fastsim_2018_.root
Going to merge because Anna is the only one with an issue