### PR TITLE
Update nEvents for PostProcessing v7

### DIFF
--- a/sampleSets_PostProcessed_2017.cfg
+++ b/sampleSets_PostProcessed_2017.cfg
@@ -164,7 +164,7 @@ WWG_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_
 
 ####POWHEG: still being produced, do not use yet
 TTToHadronic_powheg_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v7, TTToHadronic_powheg_2017.txt, Events, 380.095, 129736822, 525618, 1.0
-TTToSemiLeptonic_CP2_powheg_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v7, TTToSemiLeptonic_CP2_powheg_2017.txt, Events, 364.017888, 103940706, 421294, 1.0
+TTToSemiLeptonic_CP2_powheg_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v7, TTToSemiLeptonic_CP2_powheg_2017.txt, Events, 364.017888, 103979567, 421433, 1.0
 TTToSemiLeptonic_2017, /eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PostProcessed_18Apr2019_v7, TTToSemiLeptonic_2017.txt, Events, 364.017888, 109569608, 445136, 1.0
 
 #----------

--- a/sampleSets_PostProcessed_2018.cfg
+++ b/sampleSets_PostProcessed_2018.cfg
@@ -201,7 +201,7 @@ SMS_T2tt_mStop_350to400_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_prod
 SMS_T2tt_mStop_400to1200_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6p1_v6p5, SMS_T2tt_mStop_400to1200_fastsim_2018.txt, Events, 1, 51959144, 0, 1.0
 SMS_T2tt_mStop_1200to2000_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6p1_v6p5p1, SMS_T2tt_mStop_1200to2000_fastsim_2018.txt, Events, 1.0, 13199684, 0, 1.0
 # T5ttcc
-SMS_T5ttcc_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5p1_v6p1_v6p5, SMS_T5ttcc_fastsim_2018.txt, Events, 1.0, 44005488, 0, 1.0
+SMS_T5ttcc_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5p1_v6p1_v6p5, SMS_T5ttcc_fastsim_2018.txt, Events, 1.0, 44077578, 0, 1.0
 SMS_T5ttcc_mGluino1750to2800_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_26Apr2019_fastsimv5_v6p1_v6p5, SMS_T5ttcc_mGluino1750to2800_fastsim_2018.txt, Events, 1, 17437129, 0, 1.0
 #T2cc
 SMS_T2cc_fastsim_2018, /eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PostProcessed_28Apr2019_fastsimv5_v6p1_v6p5, SMS_T2cc_fastsim_2018.txt, Events, 1, 49922975, 0, 1


### PR DESCRIPTION
Update nEvents for PostProcessing v7 for these samples:
- TTToSemiLeptonic_CP2_powheg_2017
- SMS_T5ttcc_fastsim_2018